### PR TITLE
Fix: bypass branch protection in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR updates the publish workflow to use the `GH_PAT` secret for the checkout step. This allows the workflow to authenticate with sufficient permissions to push tags and version bumps directly to the protected `main` branch, provided the `GH_PAT` owner has 'Admin' bypass permissions in the repository ruleset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline authentication configuration to improve build and release process reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KDM-cli/kdm-cli/pull/15)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->