### PR TITLE
fix: include kdm binary wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ dist/
 .env
 .npmrc
 BLUEPRINT.md
-./bin

--- a/bin/kdm.js
+++ b/bin/kdm.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/index.js';


### PR DESCRIPTION
## Summary

- add the missing `bin/kdm.js` executable wrapper for the existing `package.json` bin entry
- keep the wrapper in the published package by allowing the `bin` directory to be committed

Fixes #19.

## Checks

- `npm ci`
- `npm run build`
- `npm test`
- packed and installed the tarball with a temporary npm prefix
- verified `kdm --version` runs from the installed package