### PR TITLE
fix(tests): ensure logger mock isolation in version-check tests

### DIFF
--- a/src/__tests__/version-check.test.ts
+++ b/src/__tests__/version-check.test.ts
@@ -58,6 +58,7 @@ describe('version-check utilities', () => {
     beforeEach(() => {
       vi.stubGlobal('fetch', fetchMock);
       vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.mocked(logger.error).mockReset();
     });
 
     afterEach(() => {


### PR DESCRIPTION
This PR fixes a test pollution issue where the 'logger.error' mock was not being reset between tests, causing failures when upgrading Vitest. This resolves the CI failures seen in several Dependabot PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation in the version check test suite by resetting test fixtures before each test case.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KDM-cli/kdm-cli/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->