### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KDM-cli/kdm-cli/security/code-scanning/1](https://github.com/KDM-cli/kdm-cli/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged.  
Best fix here: define workflow-level permissions right after the `on:` block (or before `jobs:`) with:

- `contents: read`

This is sufficient for this workflow’s current actions (checkout + dependency install + tests) and preserves existing functionality.  
File to change: **`.github/workflows/test.yml`** in the top-level section before `jobs:`.

No imports, methods, or extra definitions are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to follow security best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KDM-cli/kdm-cli/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->