### PR TITLE
fix: resolve package.json path correctly in bundled build

### DIFF
--- a/src/__tests__/version-check.test.ts
+++ b/src/__tests__/version-check.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { compareSemver, getUpdateType, checkForUpdates } from '../utils/version-check';
+import { compareSemver, getUpdateType, checkForUpdates, getInstalledVersion } from '../utils/version-check';
 import { logger } from '../utils/logger';
+import { readFileSync } from 'node:fs';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(() => JSON.stringify({ version: '1.2.2' })),
+}));
 
 vi.mock('../utils/logger', () => ({
   logger: {
@@ -96,6 +101,70 @@ describe('version-check utilities', () => {
 
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('update available!'));
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('v9.9.9'));
+    });
+  });
+
+  describe('getInstalledVersion', () => {
+    afterEach(() => {
+      vi.mocked(readFileSync).mockReset();
+    });
+
+    it('should resolve and return the version if package.json in production path is valid', () => {
+      vi.mocked(readFileSync).mockImplementation((path) => {
+        if (typeof path === 'string' && path.endsWith('src/package.json')) {
+          return JSON.stringify({ version: '2.3.4' });
+        }
+        throw new Error('File not found');
+      });
+
+      expect(getInstalledVersion()).toBe('2.3.4');
+    });
+
+    it('should resolve and return the version if production path fails but development path succeeds', () => {
+      vi.mocked(readFileSync).mockImplementation((path) => {
+        if (typeof path === 'string' && path.endsWith('package.json') && !path.endsWith('src/package.json')) {
+          return JSON.stringify({ version: '1.2.3' });
+        }
+        throw new Error('File not found');
+      });
+
+      expect(getInstalledVersion()).toBe('1.2.3');
+    });
+
+    it('should advance to the next path if JSON is malformed', () => {
+      vi.mocked(readFileSync).mockImplementation((path) => {
+        if (typeof path === 'string' && path.endsWith('src/package.json')) {
+          return '{ malformed json';
+        }
+        if (typeof path === 'string' && path.endsWith('package.json') && !path.endsWith('src/package.json')) {
+          return JSON.stringify({ version: '1.2.9' });
+        }
+        throw new Error('File not found');
+      });
+
+      expect(getInstalledVersion()).toBe('1.2.9');
+    });
+
+    it('should advance to next path if version is not a string or missing', () => {
+      vi.mocked(readFileSync).mockImplementation((path) => {
+        if (typeof path === 'string' && path.endsWith('src/package.json')) {
+          return JSON.stringify({ version: 12345 }); // non-string version
+        }
+        if (typeof path === 'string' && path.endsWith('package.json') && !path.endsWith('src/package.json')) {
+          return JSON.stringify({ version: '1.2.8' });
+        }
+        throw new Error('File not found');
+      });
+
+      expect(getInstalledVersion()).toBe('1.2.8');
+    });
+
+    it('should fallback to 0.0.0 if both paths fail', () => {
+      vi.mocked(readFileSync).mockImplementation(() => {
+        throw new Error('Read failed');
+      });
+
+      expect(getInstalledVersion()).toBe('0.0.0');
     });
   });
 });

--- a/src/utils/version-check.ts
+++ b/src/utils/version-check.ts
@@ -9,13 +9,19 @@ const __dirname = dirname(__filename);
 
 // Read the actual package.json version at runtime
 function getInstalledVersion(): string {
-  const pkgPath = join(__dirname, '..', '..', 'package.json');
-  try {
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    return pkg.version || '0.0.0';
-  } catch {
-    return '0.0.0';
+  const paths = [
+    join(__dirname, '..', 'package.json'),      // production: dist/../package.json
+    join(__dirname, '..', '..', 'package.json') // development: src/utils/../../package.json
+  ];
+  for (const pkgPath of paths) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      if (pkg.version) return pkg.version;
+    } catch {
+      // Try next path
+    }
   }
+  return '0.0.0';
 }
 
 // Compare two semver strings; returns 'lt' if a < b, 'gt' if a > b, 'eq' if equal

--- a/src/utils/version-check.ts
+++ b/src/utils/version-check.ts
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Read the actual package.json version at runtime
-function getInstalledVersion(): string {
+export function getInstalledVersion(): string {
   const paths = [
     join(__dirname, '..', 'package.json'),      // production: dist/../package.json
     join(__dirname, '..', '..', 'package.json') // development: src/utils/../../package.json
@@ -16,7 +16,7 @@ function getInstalledVersion(): string {
   for (const pkgPath of paths) {
     try {
       const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-      if (pkg.version) return pkg.version;
+      if (typeof pkg.version === 'string' && pkg.version) return pkg.version;
     } catch {
       // Try next path
     }


### PR DESCRIPTION
Resolves #47

This PR resolves the issue where the update notification displays `Current Version : v0.0.0` instead of the actual installed version (e.g., `1.2.2`).

- Update `getInstalledVersion` inside `src/utils/version-check.ts` to probe multiple relative paths:
  1. `dist/../package.json` (production/bundled build)
  2. `src/utils/../../package.json` (development/testing)
- Tested both contexts, ensuring the build outputs compile successfully and retrieve correct versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection reliability by checking multiple runtime layouts and gracefully falling back to a default when version information is unavailable.
* **New Features**
  * Exposed a utility to read the installed application version at runtime for broader visibility.
* **Tests**
  * Added coverage validating version resolution across different layout and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KDM-cli/kdm-cli/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->