### PR TITLE
test: normalize mocked package path suffixes

### DIFF
--- a/src/__tests__/version-check.test.ts
+++ b/src/__tests__/version-check.test.ts
@@ -115,6 +115,7 @@ describe('version-check utilities', () => {
     it('should treat Windows and POSIX separators the same when matching package paths', () => {
       expect(hasPathSuffix('C:\\repo\\src\\package.json', 'src/package.json')).toBe(true);
       expect(hasPathSuffix('/repo/src/package.json', 'src/package.json')).toBe(true);
+      expect(hasPathSuffix('/repo/src/package.json', 'src/other.json')).toBe(false);
     });
 
     it('should resolve and return the version if package.json in production path is valid', () => {

--- a/src/__tests__/version-check.test.ts
+++ b/src/__tests__/version-check.test.ts
@@ -13,6 +13,9 @@ vi.mock('../utils/logger', () => ({
   },
 }));
 
+const hasPathSuffix = (path: string, suffix: string) =>
+  path.replaceAll('\\', '/').endsWith(suffix);
+
 describe('version-check utilities', () => {
   describe('compareSemver', () => {
     it('should return "lt" if a < b', () => {
@@ -109,9 +112,14 @@ describe('version-check utilities', () => {
       vi.mocked(readFileSync).mockReset();
     });
 
+    it('should treat Windows and POSIX separators the same when matching package paths', () => {
+      expect(hasPathSuffix('C:\\repo\\src\\package.json', 'src/package.json')).toBe(true);
+      expect(hasPathSuffix('/repo/src/package.json', 'src/package.json')).toBe(true);
+    });
+
     it('should resolve and return the version if package.json in production path is valid', () => {
       vi.mocked(readFileSync).mockImplementation((path) => {
-        if (typeof path === 'string' && path.endsWith('src/package.json')) {
+        if (typeof path === 'string' && hasPathSuffix(path, 'src/package.json')) {
           return JSON.stringify({ version: '2.3.4' });
         }
         throw new Error('File not found');
@@ -122,7 +130,7 @@ describe('version-check utilities', () => {
 
     it('should resolve and return the version if production path fails but development path succeeds', () => {
       vi.mocked(readFileSync).mockImplementation((path) => {
-        if (typeof path === 'string' && path.endsWith('package.json') && !path.endsWith('src/package.json')) {
+        if (typeof path === 'string' && hasPathSuffix(path, 'package.json') && !hasPathSuffix(path, 'src/package.json')) {
           return JSON.stringify({ version: '1.2.3' });
         }
         throw new Error('File not found');
@@ -133,10 +141,10 @@ describe('version-check utilities', () => {
 
     it('should advance to the next path if JSON is malformed', () => {
       vi.mocked(readFileSync).mockImplementation((path) => {
-        if (typeof path === 'string' && path.endsWith('src/package.json')) {
+        if (typeof path === 'string' && hasPathSuffix(path, 'src/package.json')) {
           return '{ malformed json';
         }
-        if (typeof path === 'string' && path.endsWith('package.json') && !path.endsWith('src/package.json')) {
+        if (typeof path === 'string' && hasPathSuffix(path, 'package.json') && !hasPathSuffix(path, 'src/package.json')) {
           return JSON.stringify({ version: '1.2.9' });
         }
         throw new Error('File not found');
@@ -147,10 +155,10 @@ describe('version-check utilities', () => {
 
     it('should advance to next path if version is not a string or missing', () => {
       vi.mocked(readFileSync).mockImplementation((path) => {
-        if (typeof path === 'string' && path.endsWith('src/package.json')) {
+        if (typeof path === 'string' && hasPathSuffix(path, 'src/package.json')) {
           return JSON.stringify({ version: 12345 }); // non-string version
         }
-        if (typeof path === 'string' && path.endsWith('package.json') && !path.endsWith('src/package.json')) {
+        if (typeof path === 'string' && hasPathSuffix(path, 'package.json') && !hasPathSuffix(path, 'src/package.json')) {
           return JSON.stringify({ version: '1.2.8' });
         }
         throw new Error('File not found');


### PR DESCRIPTION
## Summary
- normalize mocked file paths in `version-check.test.ts` before suffix checks
- update every `package.json` path guard to work with both `\` and `/`
- add a focused regression assertion covering Windows and POSIX path separators

## Validation
- `git diff --check`
- attempted `npm test`, but this runner only has Node.js `v12.22.9` while the repo's Vitest stack requires a newer Node runtime; the change is test-only and scoped to path matching logic

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform path handling in version-detection tests to ensure consistent behavior on Windows and POSIX systems.
  * Updated test mocks and routing to use normalized suffix matching.
  * Added a unit test verifying Windows-style and POSIX-style path variants are treated equivalently for version resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KDM-cli/kdm-cli/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->