### PR TITLE
feat: implement Phase 4 (Filters) and Phase 5 (AI Auth & Provider System)

### DIFF
--- a/coding_style.md
+++ b/coding_style.md
@@ -14,6 +14,8 @@ We enforce the **Bare Minimum** quality gate profile on PR delta analysis:
 | **Nesting Depth** | Strictly `< 4` levels of indentation | `10.00 / 10.00` |
 | **Bumpy Road Ahead** | Max `1` nested conditional block per function | `10.00 / 10.00` |
 | **Docstring Coverage** | Strictly `> 80%` of functions & modules documented | Green check |
+| **Mean Module Complexity** | Strictly `< 4.0` average cyclomatic complexity per module | Green check |
+| **String-Heavy Arguments** | Strictly `< 39%` of all arguments across a module's functions may be strings | Green check |
 
 ---
 
@@ -90,6 +92,54 @@ CodeScene checks for standard JSDoc/TSDoc blocks on functions and modules.
   1. A clear sentence of what it does.
   2. Description of every `@param`.
   3. Description of the `@returns` type.
+
+### 5. Mean Module Complexity & String-Heavy Arguments
+CodeScene flags modules that have a high average cyclomatic complexity or contain too many string arguments across their functions.
+* **Rule (Mean Complexity)**: Keep the mean cyclomatic complexity across all functions in a module **strictly < 4.0**. Avoid piling too many branch structures into a single file.
+* **Rule (String-Heavy arguments)**: Keep the ratio of primitive string arguments (like `string`, `string[]`, or similar) **strictly < 39%** of all function arguments across a module.
+* **Pattern**: 
+  - Instead of passing multiple primitive parameters (especially strings) to a function, group them into a typed parameter options object.
+  - Inline simple single-use helper functions to keep function count low and reduce unnecessary function parameter overhead.
+
+```typescript
+// ❌ BAD: High primitive string argument density
+const resolveProvider = (name: string, model: string, baseUrl: string, password?: string) => ...
+
+// 🟢 GOOD: Grouped parameter options object (0 primitive string arguments)
+interface ProviderParams {
+  name: string;
+  model: string;
+  baseUrl: string;
+  password?: string;
+}
+const resolveProvider = (params: ProviderParams) => ...
+```
+
+### 6. Code Duplication & Parameterized Testing
+Duplicate logic or structurally identical functions trigger CodeScene warnings, including inside unit tests.
+* **Rule**: Never copy-paste structural logic across test cases.
+* **Pattern**: Use parameterized testing templates (`it.each`) in Vitest to run similar assertions through a single test function body.
+
+```typescript
+// ❌ BAD: Structural code duplication in tests
+it('tests provider A', () => {
+  const result = runTest('A', 'paramA');
+  expect(result).toBe('respA');
+});
+it('tests provider B', () => {
+  const result = runTest('B', 'paramB');
+  expect(result).toBe('respB');
+});
+
+// 🟢 GOOD: Parameterized it.each
+it.each([
+  { name: 'A', param: 'paramA', expected: 'respA' },
+  { name: 'B', param: 'paramB', expected: 'respB' }
+])('tests provider $name', ({ name, param, expected }) => {
+  const result = runTest(name, param);
+  expect(result).toBe(expected);
+});
+```
 
 ---
 

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -3,9 +3,13 @@ import { Command } from 'commander';
 import { registerAuthCommand } from '../commands/auth';
 import { getAIConfig, setAIConfig } from '../config/store';
 import { createAIClient } from '../ai/factory';
+import { OllamaAIClient } from '../ai/ollama';
+import { OpenAIAIClient } from '../ai/openai';
+import { AnthropicAIClient } from '../ai/anthropic';
+import { CustomRestAIClient } from '../ai/custom-rest';
 
 const { mockStore } = vi.hoisted(() => ({
-  mockStore: { providers: [] as any[], defaultProvider: undefined as string | undefined }
+  mockStore: { providers: [] as any[], defaultProvider: undefined as string | undefined },
 }));
 
 vi.mock('../config/store', () => ({
@@ -42,6 +46,32 @@ describe('auth command & AI clients', () => {
   afterEach(() => {
     process.exitCode = undefined;
   });
+
+  const runAIClientTest = async (
+    backend: string,
+    addArgs: string[],
+    mockJson: any,
+    expectedUrl: string,
+    bodyExpectations: (body: any) => void,
+    headersExpectations: (headers: any) => void,
+  ) => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockJson,
+    } as Response);
+
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', backend, ...addArgs]);
+    const client = await createAIClient(backend);
+    await client.getCompletion('test-prompt');
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [calledUrl, calledOptions] = fetchSpy.mock.calls[0];
+    expect(calledUrl).toBe(expectedUrl);
+    expect(calledOptions.method).toBe('POST');
+    bodyExpectations(JSON.parse(calledOptions.body));
+    headersExpectations(calledOptions.headers);
+  };
 
   it('adds a provider with defaults', async () => {
     await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'mykey']);
@@ -80,13 +110,25 @@ describe('auth command & AI clients', () => {
       'gpt-4-turbo',
       '-p',
       'newkey',
+      '--temperature',
+      '0.9',
+      '--topp',
+      '0.85',
+      '--topk',
+      '20',
+      '--maxtokens',
+      '500',
+      '--custom-header',
+      'X-Test=HeaderVal',
     ]);
     const config = getAIConfig();
     expect(config.providers[0].model).toBe('gpt-4-turbo');
     expect(config.providers[0].password).toBe('newkey');
-    expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Successfully updated AI provider "openai"'),
-    );
+    expect(config.providers[0].temperature).toBe(0.9);
+    expect(config.providers[0].topP).toBe(0.85);
+    expect(config.providers[0].topK).toBe(20);
+    expect(config.providers[0].maxTokens).toBe(500);
+    expect(config.providers[0].customHeaders).toEqual({ 'X-Test': 'HeaderVal' });
   });
 
   it('lists providers and masks secrets', async () => {
@@ -105,15 +147,17 @@ describe('auth command & AI clients', () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('supe...ikey'));
   });
 
+  it('shows empty list message', async () => {
+    await program.parseAsync(['node', 'test', 'auth', 'list']);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('No AI providers configured.'));
+  });
+
   it('sets a default provider', async () => {
     await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'key1']);
     await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'anthropic', '-p', 'key2']);
     await program.parseAsync(['node', 'test', 'auth', 'default', 'anthropic']);
     const config = getAIConfig();
     expect(config.defaultProvider).toBe('anthropic');
-    expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Successfully set default AI provider to "anthropic"'),
-    );
   });
 
   it('removes a provider', async () => {
@@ -132,106 +176,223 @@ describe('auth command & AI clients', () => {
     expect(result).toBe('noop completion explanation');
   });
 
-  it('queries Custom REST provider', async () => {
+  // Parameterized tests for various client endpoints and options to avoid CodeScene duplication
+  it.each([
+    {
+      backend: 'customrest',
+      addArgs: ['-u', 'http://custom-endpoint.com/api', '--custom-header', 'X-Key=Value', '-p', 'customkey'],
+      mockJson: { response: 'custom response text' },
+      expectedUrl: 'http://custom-endpoint.com/api',
+      bodyExpectations: (body: any) => {
+        expect(body.prompt).toBe('test-prompt');
+        expect(body.temperature).toBe(0.7);
+      },
+      headersExpectations: (headers: any) => {
+        expect(headers['X-Key']).toBe('Value');
+        expect(headers['Authorization']).toBe('Bearer customkey');
+      },
+    },
+    {
+      backend: 'ollama',
+      addArgs: ['-u', 'http://localhost:11434/'],
+      mockJson: { response: 'ollama response' },
+      expectedUrl: 'http://localhost:11434/api/generate',
+      bodyExpectations: (body: any) => expect(body.prompt).toBe('test-prompt'),
+      headersExpectations: () => {},
+    },
+    {
+      backend: 'openai',
+      addArgs: ['-p', 'opensecretkey', '-u', 'https://api.openai.com/v1/'],
+      mockJson: { choices: [{ message: { content: 'openai reply' } }] },
+      expectedUrl: 'https://api.openai.com/v1/chat/completions',
+      bodyExpectations: (body: any) => expect(body.messages[0].content).toBe('test-prompt'),
+      headersExpectations: (headers: any) => expect(headers['Authorization']).toBe('Bearer opensecretkey'),
+    },
+    {
+      backend: 'openai',
+      addArgs: ['-p', 'opensecretkey', '-u', 'https://api.openai.com/v1'],
+      mockJson: { choices: [{ message: { content: 'openai reply v1' } }] },
+      expectedUrl: 'https://api.openai.com/v1/chat/completions',
+      bodyExpectations: (body: any) => expect(body.messages[0].content).toBe('test-prompt'),
+      headersExpectations: (headers: any) => expect(headers['Authorization']).toBe('Bearer opensecretkey'),
+    },
+    {
+      backend: 'openai',
+      addArgs: ['-p', 'opensecretkey', '-u', 'https://api.openai.com/chat/completions'],
+      mockJson: { choices: [{ message: { content: 'openai reply exact' } }] },
+      expectedUrl: 'https://api.openai.com/chat/completions',
+      bodyExpectations: (body: any) => expect(body.messages[0].content).toBe('test-prompt'),
+      headersExpectations: (headers: any) => expect(headers['Authorization']).toBe('Bearer opensecretkey'),
+    },
+    {
+      backend: 'openai',
+      addArgs: ['-p', 'opensecretkey', '-u', 'https://my-custom-endpoint.com'],
+      mockJson: { choices: [{ message: { content: 'openai reply generic' } }] },
+      expectedUrl: 'https://my-custom-endpoint.com/chat/completions',
+      bodyExpectations: (body: any) => expect(body.messages[0].content).toBe('test-prompt'),
+      headersExpectations: (headers: any) => expect(headers['Authorization']).toBe('Bearer opensecretkey'),
+    },
+    {
+      backend: 'anthropic',
+      addArgs: ['-p', 'anthropicsecretkey', '-u', 'https://api.anthropic.com/v1/'],
+      mockJson: { content: [{ text: 'claude response' }] },
+      expectedUrl: 'https://api.anthropic.com/v1/messages',
+      bodyExpectations: (body: any) => expect(body.messages[0].content).toBe('test-prompt'),
+      headersExpectations: (headers: any) => {
+        expect(headers['x-api-key']).toBe('anthropicsecretkey');
+        expect(headers['anthropic-version']).toBe('2023-06-01');
+      },
+    },
+    {
+      backend: 'anthropic',
+      addArgs: ['-p', 'anthropicsecretkey', '-u', 'https://api.anthropic.com/v1'],
+      mockJson: { content: [{ text: 'claude response v1' }] },
+      expectedUrl: 'https://api.anthropic.com/v1/messages',
+      bodyExpectations: (body: any) => expect(body.messages[0].content).toBe('test-prompt'),
+      headersExpectations: (headers: any) => {
+        expect(headers['x-api-key']).toBe('anthropicsecretkey');
+        expect(headers['anthropic-version']).toBe('2023-06-01');
+      },
+    },
+    {
+      backend: 'anthropic',
+      addArgs: ['-p', 'anthropicsecretkey', '-u', 'https://api.anthropic.com/messages'],
+      mockJson: { content: [{ text: 'claude response exact' }] },
+      expectedUrl: 'https://api.anthropic.com/messages',
+      bodyExpectations: (body: any) => expect(body.messages[0].content).toBe('test-prompt'),
+      headersExpectations: (headers: any) => {
+        expect(headers['x-api-key']).toBe('anthropicsecretkey');
+      },
+    },
+    {
+      backend: 'anthropic',
+      addArgs: ['-p', 'anthropicsecretkey', '-u', 'https://my-custom-endpoint.com'],
+      mockJson: { content: [{ text: 'claude response generic' }] },
+      expectedUrl: 'https://my-custom-endpoint.com/messages',
+      bodyExpectations: (body: any) => expect(body.messages[0].content).toBe('test-prompt'),
+      headersExpectations: (headers: any) => {
+        expect(headers['x-api-key']).toBe('anthropicsecretkey');
+      },
+    },
+  ])(
+    'queries $backend provider client completion with url options: $addArgs',
+    async ({ backend, addArgs, mockJson, expectedUrl, bodyExpectations, headersExpectations }) => {
+      await runAIClientTest(
+        backend,
+        addArgs,
+        mockJson,
+        expectedUrl,
+        bodyExpectations,
+        headersExpectations,
+      );
+    },
+  );
+
+  // Testing client configure default/fallback branches
+  it('covers fallback default configurations', async () => {
+    const ollama = new OllamaAIClient();
+    await ollama.configure({ name: 'ollama' });
+    // Verify default options
+    expect((ollama as any).config.baseUrl).toBe('http://localhost:11434');
+    expect((ollama as any).config.model).toBe('llama3.1');
+
+    const openai = new OpenAIAIClient();
+    await openai.configure({ name: 'openai', password: 'key' });
+    expect((openai as any).config.baseUrl).toBe('https://api.openai.com/v1/chat/completions');
+    expect((openai as any).config.model).toBe('gpt-4o');
+
+    const anthropic = new AnthropicAIClient();
+    await anthropic.configure({ name: 'anthropic', password: 'key' });
+    expect((anthropic as any).config.baseUrl).toBe('https://api.anthropic.com/v1/messages');
+    expect((anthropic as any).config.model).toBe('claude-3-5-sonnet-latest');
+  });
+
+  // Testing failed completion scenarios
+  it.each([
+    { ClientClass: OpenAIAIClient, name: 'openai', config: { name: 'openai', password: 'key' } },
+    { ClientClass: AnthropicAIClient, name: 'anthropic', config: { name: 'anthropic', password: 'key' } },
+    { ClientClass: OllamaAIClient, name: 'ollama', config: { name: 'ollama' } },
+    { ClientClass: CustomRestAIClient, name: 'customrest', config: { name: 'customrest', baseUrl: 'http://test' } },
+  ])('fails getCompletion on non-ok HTTP responses for $name', async ({ ClientClass, config }) => {
     fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ response: 'custom response text' }),
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
     } as Response);
 
-    await program.parseAsync([
-      'node',
-      'test',
-      'auth',
-      'add',
-      '-b',
-      'customrest',
-      '-u',
-      'http://custom-endpoint.com/api',
-    ]);
-    const client = await createAIClient('customrest');
-    const result = await client.getCompletion('custom prompt');
-    expect(result).toBe('custom response text');
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'http://custom-endpoint.com/api',
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.stringContaining('"prompt":"custom prompt"'),
-      }),
+    const client = new ClientClass();
+    await client.configure(config);
+    await expect(client.getCompletion('fail')).rejects.toThrow('failed with status 500');
+  });
+
+  // Client validation checks
+  it('validates required configuration inputs', async () => {
+    const openai = new OpenAIAIClient();
+    await expect(openai.configure({ name: 'openai' })).rejects.toThrow(
+      'API key (password) is required for openai',
+    );
+
+    const anthropic = new AnthropicAIClient();
+    await expect(anthropic.configure({ name: 'anthropic' })).rejects.toThrow(
+      'API key (password) is required for anthropic',
+    );
+
+    const customrest = new CustomRestAIClient();
+    await expect(customrest.configure({ name: 'customrest' })).rejects.toThrow(
+      'baseUrl is required for customrest',
     );
   });
 
-  it('queries Ollama provider', async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ response: 'ollama response text' }),
-    } as Response);
-
-    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'ollama']);
-    const client = await createAIClient('ollama');
-    const result = await client.getCompletion('ollama prompt');
-    expect(result).toBe('ollama response text');
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'http://localhost:11434/api/generate',
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.stringContaining('"prompt":"ollama prompt"'),
-      }),
-    );
+  it('handles client validation errors', async () => {
+    await expect(createAIClient('unsupported')).rejects.toThrow('Unsupported AI provider');
   });
 
-  it('queries OpenAI provider', async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ choices: [{ message: { content: 'openai reply' } }] }),
-    } as Response);
+  it('handles auth operations on missing providers', async () => {
+    await program.parseAsync(['node', 'test', 'auth', 'update', 'openai', '-m', 'some-model']);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('is not configured'));
+    expect(process.exitCode).toBe(1);
 
-    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'opensecretkey']);
-    const client = await createAIClient('openai');
-    const result = await client.getCompletion('hello gpt');
-    expect(result).toBe('openai reply');
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'https://api.openai.com/v1/chat/completions',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          Authorization: 'Bearer opensecretkey',
-        }),
-      }),
-    );
+    errorSpy.mockClear();
+    process.exitCode = undefined;
+    await program.parseAsync(['node', 'test', 'auth', 'default', 'openai']);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('is not configured'));
+    expect(process.exitCode).toBe(1);
+
+    errorSpy.mockClear();
+    process.exitCode = undefined;
+    await program.parseAsync(['node', 'test', 'auth', 'remove', 'openai']);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('is not configured'));
+    expect(process.exitCode).toBe(1);
   });
 
-  it('queries Anthropic provider', async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ content: [{ text: 'claude response' }] }),
-    } as Response);
+  it('validates invalid backend parameter on add, update, default, remove', async () => {
+    // resolveNewBackend validation
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'invalid-backend']);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unsupported backend'));
+    expect(process.exitCode).toBe(1);
 
-    await program.parseAsync([
-      'node',
-      'test',
-      'auth',
-      'add',
-      '-b',
-      'anthropic',
-      '-p',
-      'anthropicsecretkey',
-    ]);
-    const client = await createAIClient('anthropic');
-    const result = await client.getCompletion('hello claude');
-    expect(result).toBe('claude response');
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'https://api.anthropic.com/v1/messages',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          'x-api-key': 'anthropicsecretkey',
-          'anthropic-version': '2023-06-01',
-        }),
-      }),
-    );
+    // resolveProviderContext validation
+    errorSpy.mockClear();
+    process.exitCode = undefined;
+    await program.parseAsync(['node', 'test', 'auth', 'update', 'invalid-backend']);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unsupported backend'));
+    expect(process.exitCode).toBe(1);
+
+    errorSpy.mockClear();
+    process.exitCode = undefined;
+    await program.parseAsync(['node', 'test', 'auth', 'default', 'invalid-backend']);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unsupported backend'));
+    expect(process.exitCode).toBe(1);
+
+    errorSpy.mockClear();
+    process.exitCode = undefined;
+    await program.parseAsync(['node', 'test', 'auth', 'remove', 'invalid-backend']);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unsupported backend'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('creates AI client without configuration (using default/fallback config)', async () => {
+    const client = await createAIClient('noop');
+    expect(client.name).toBe('noop');
   });
 });

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { registerAuthCommand } from '../commands/auth';
+import { getAIConfig, setAIConfig } from '../config/store';
+import { createAIClient } from '../ai/factory';
+
+const { mockStore } = vi.hoisted(() => ({
+  mockStore: { providers: [] as any[], defaultProvider: undefined as string | undefined }
+}));
+
+vi.mock('../config/store', () => ({
+  getAIConfig: vi.fn(() => mockStore),
+  setAIConfig: vi.fn((config) => {
+    mockStore.providers = config.providers;
+    mockStore.defaultProvider = config.defaultProvider;
+  }),
+}));
+
+describe('auth command & AI clients', () => {
+  let program: Command;
+  let logSpy: any;
+  let errorSpy: any;
+  let fetchSpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAIConfig({ providers: [], defaultProvider: undefined });
+
+    program = new Command();
+    registerAuthCommand(program);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      } as Response;
+    });
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it('adds a provider with defaults', async () => {
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'mykey']);
+    const config = getAIConfig();
+    expect(config.providers).toHaveLength(1);
+    expect(config.providers[0]).toEqual(
+      expect.objectContaining({
+        name: 'openai',
+        model: 'gpt-4o',
+        password: 'mykey',
+        temperature: 0.7,
+      }),
+    );
+    expect(config.defaultProvider).toBe('openai');
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Successfully added AI provider "openai"'),
+    );
+  });
+
+  it('rejects duplicate providers on add', async () => {
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'key1']);
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'key2']);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('already configured'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('updates an existing provider', async () => {
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'key1']);
+    await program.parseAsync([
+      'node',
+      'test',
+      'auth',
+      'update',
+      'openai',
+      '-m',
+      'gpt-4-turbo',
+      '-p',
+      'newkey',
+    ]);
+    const config = getAIConfig();
+    expect(config.providers[0].model).toBe('gpt-4-turbo');
+    expect(config.providers[0].password).toBe('newkey');
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Successfully updated AI provider "openai"'),
+    );
+  });
+
+  it('lists providers and masks secrets', async () => {
+    await program.parseAsync([
+      'node',
+      'test',
+      'auth',
+      'add',
+      '--backend',
+      'openai',
+      '--password',
+      'supersecretapikey',
+    ]);
+    await program.parseAsync(['node', 'test', 'auth', 'list']);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('openai'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('supe...ikey'));
+  });
+
+  it('sets a default provider', async () => {
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'key1']);
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'anthropic', '-p', 'key2']);
+    await program.parseAsync(['node', 'test', 'auth', 'default', 'anthropic']);
+    const config = getAIConfig();
+    expect(config.defaultProvider).toBe('anthropic');
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Successfully set default AI provider to "anthropic"'),
+    );
+  });
+
+  it('removes a provider', async () => {
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'key1']);
+    await program.parseAsync(['node', 'test', 'auth', 'remove', 'openai']);
+    const config = getAIConfig();
+    expect(config.providers).toHaveLength(0);
+    expect(config.defaultProvider).toBeUndefined();
+  });
+
+  it('creates Noop client and returns deterministic text', async () => {
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'noop']);
+    const client = await createAIClient('noop');
+    expect(client.name).toBe('noop');
+    const result = await client.getCompletion('test prompt');
+    expect(result).toBe('noop completion explanation');
+  });
+
+  it('queries Custom REST provider', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ response: 'custom response text' }),
+    } as Response);
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'auth',
+      'add',
+      '-b',
+      'customrest',
+      '-u',
+      'http://custom-endpoint.com/api',
+    ]);
+    const client = await createAIClient('customrest');
+    const result = await client.getCompletion('custom prompt');
+    expect(result).toBe('custom response text');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://custom-endpoint.com/api',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"prompt":"custom prompt"'),
+      }),
+    );
+  });
+
+  it('queries Ollama provider', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ response: 'ollama response text' }),
+    } as Response);
+
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'ollama']);
+    const client = await createAIClient('ollama');
+    const result = await client.getCompletion('ollama prompt');
+    expect(result).toBe('ollama response text');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://localhost:11434/api/generate',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"prompt":"ollama prompt"'),
+      }),
+    );
+  });
+
+  it('queries OpenAI provider', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [{ message: { content: 'openai reply' } }] }),
+    } as Response);
+
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', 'openai', '-p', 'opensecretkey']);
+    const client = await createAIClient('openai');
+    const result = await client.getCompletion('hello gpt');
+    expect(result).toBe('openai reply');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer opensecretkey',
+        }),
+      }),
+    );
+  });
+
+  it('queries Anthropic provider', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ content: [{ text: 'claude response' }] }),
+    } as Response);
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'auth',
+      'add',
+      '-b',
+      'anthropic',
+      '-p',
+      'anthropicsecretkey',
+    ]);
+    const client = await createAIClient('anthropic');
+    const result = await client.getCompletion('hello claude');
+    expect(result).toBe('claude response');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/messages',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'x-api-key': 'anthropicsecretkey',
+          'anthropic-version': '2023-06-01',
+        }),
+      }),
+    );
+  });
+});

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -47,30 +47,30 @@ describe('auth command & AI clients', () => {
     process.exitCode = undefined;
   });
 
-  const runAIClientTest = async (
-    backend: string,
-    addArgs: string[],
-    mockJson: any,
-    expectedUrl: string,
-    bodyExpectations: (body: any) => void,
-    headersExpectations: (headers: any) => void,
-  ) => {
+  const runAIClientTest = async (params: {
+    backend: string;
+    addArgs: string[];
+    mockJson: any;
+    expectedUrl: string;
+    bodyExpectations: (body: any) => void;
+    headersExpectations: (headers: any) => void;
+  }) => {
     fetchSpy.mockResolvedValueOnce({
       ok: true,
       status: 200,
-      json: async () => mockJson,
+      json: async () => params.mockJson,
     } as Response);
 
-    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', backend, ...addArgs]);
-    const client = await createAIClient(backend);
+    await program.parseAsync(['node', 'test', 'auth', 'add', '-b', params.backend, ...params.addArgs]);
+    const client = await createAIClient(params.backend);
     await client.getCompletion('test-prompt');
 
     expect(fetchSpy).toHaveBeenCalled();
     const [calledUrl, calledOptions] = fetchSpy.mock.calls[0];
-    expect(calledUrl).toBe(expectedUrl);
+    expect(calledUrl).toBe(params.expectedUrl);
     expect(calledOptions.method).toBe('POST');
-    bodyExpectations(JSON.parse(calledOptions.body));
-    headersExpectations(calledOptions.headers);
+    params.bodyExpectations(JSON.parse(calledOptions.body));
+    params.headersExpectations(calledOptions.headers);
   };
 
   it('adds a provider with defaults', async () => {
@@ -277,14 +277,14 @@ describe('auth command & AI clients', () => {
   ])(
     'queries $backend provider client completion with url options: $addArgs',
     async ({ backend, addArgs, mockJson, expectedUrl, bodyExpectations, headersExpectations }) => {
-      await runAIClientTest(
+      await runAIClientTest({
         backend,
         addArgs,
         mockJson,
         expectedUrl,
         bodyExpectations,
         headersExpectations,
-      );
+      });
     },
   );
 

--- a/src/__tests__/filters.test.ts
+++ b/src/__tests__/filters.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { registerFiltersCommand } from '../commands/filters';
+import { getActiveFilters, setActiveFilters } from '../config/store';
+
+vi.mock('../config/store', () => ({
+  getActiveFilters: vi.fn(() => []),
+  setActiveFilters: vi.fn(),
+}));
+
+describe('filters command', () => {
+  let program: Command;
+  let logSpy: any;
+  let errorSpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    program = new Command();
+    registerFiltersCommand(program);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it('lists active and available but inactive filters with empty activeFilters', async () => {
+    await program.parseAsync(['node', 'test', 'filters', 'list']);
+    expect(getActiveFilters).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Active filters:'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('- Pod'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('- Deployment'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Available but inactive filters:'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('(none)'));
+  });
+
+  it('lists active and available but inactive filters with explicit activeFilters', async () => {
+    vi.mocked(getActiveFilters).mockReturnValueOnce(['Pod']);
+    await program.parseAsync(['node', 'test', 'filters', 'list']);
+    
+    const calls = logSpy.mock.calls.map((c: any) => c[0]);
+    const activeIndex = calls.indexOf('Active filters:');
+    const inactiveIndex = calls.indexOf('Available but inactive filters:');
+    
+    expect(activeIndex).toBeGreaterThanOrEqual(0);
+    expect(inactiveIndex).toBeGreaterThanOrEqual(0);
+    
+    const podIndex = calls.indexOf('- Pod');
+    expect(podIndex).toBeGreaterThan(activeIndex);
+    expect(podIndex).toBeLessThan(inactiveIndex);
+    
+    const depIndex = calls.indexOf('- Deployment');
+    expect(depIndex).toBeGreaterThan(inactiveIndex);
+  });
+
+  it('adds a valid filter successfully', async () => {
+    vi.mocked(getActiveFilters).mockReturnValueOnce(['Pod']);
+    await program.parseAsync(['node', 'test', 'filters', 'add', 'Deployment']);
+    expect(setActiveFilters).toHaveBeenCalledWith(['Pod', 'Deployment']);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Successfully added filter "Deployment"'));
+  });
+
+  it('reports duplicate filter adds', async () => {
+    vi.mocked(getActiveFilters).mockReturnValueOnce(['Pod']);
+    await program.parseAsync(['node', 'test', 'filters', 'add', 'Pod']);
+    expect(setActiveFilters).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('is already active'));
+  });
+
+  it('rejects an invalid filter name on add', async () => {
+    await program.parseAsync(['node', 'test', 'filters', 'add', 'InvalidName']);
+    expect(setActiveFilters).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown filter name'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('removes an active filter', async () => {
+    vi.mocked(getActiveFilters).mockReturnValueOnce(['Pod', 'Deployment']);
+    await program.parseAsync(['node', 'test', 'filters', 'remove', 'Pod']);
+    expect(setActiveFilters).toHaveBeenCalledWith(['Deployment']);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Successfully removed filter "Pod"'));
+  });
+
+  it('reports no-op when removing an inactive filter', async () => {
+    vi.mocked(getActiveFilters).mockReturnValueOnce(['Pod']);
+    await program.parseAsync(['node', 'test', 'filters', 'remove', 'Deployment']);
+    expect(setActiveFilters).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('is not currently active'));
+  });
+
+  it('removes a default filter when activeFilters is empty', async () => {
+    vi.mocked(getActiveFilters).mockReturnValueOnce([]);
+    await program.parseAsync(['node', 'test', 'filters', 'remove', 'Pod']);
+    expect(setActiveFilters).toHaveBeenCalledWith([
+      'Deployment',
+      'Service',
+      'PersistentVolumeClaim',
+      'Node',
+    ]);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Successfully removed default filter "Pod"'),
+    );
+  });
+
+  it('reports error when removing an invalid filter', async () => {
+    await program.parseAsync(['node', 'test', 'filters', 'remove', 'InvalidName']);
+    expect(setActiveFilters).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown filter name'));
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -2,6 +2,43 @@ import { AIClient } from './types';
 import { AIProviderConfig } from '../config/schema';
 
 /**
+ * Formats the Anthropic URL based on custom base url configurations.
+ * @param baseUrl Configured base URL or undefined.
+ * @returns Formatted messages URL.
+ */
+const formatAnthropicUrl = (baseUrl?: string): string => {
+  const base = baseUrl || 'https://api.anthropic.com/v1/messages';
+  const url = base.replace(/\/$/, '');
+  if (url.endsWith('/v1')) {
+    return `${url}/messages`;
+  }
+  if (!url.includes('/messages')) {
+    return `${url}/messages`;
+  }
+  return url;
+};
+
+/**
+ * Builds the Anthropic payload body.
+ * @param model Model name.
+ * @param prompt Prompt text.
+ * @param temp Temperature.
+ * @param maxTokens MaxTokens.
+ * @returns Payload body object.
+ */
+const buildAnthropicBody = (
+  model: string,
+  prompt: string,
+  temp?: number,
+  maxTokens?: number,
+) => ({
+  model,
+  messages: [{ role: 'user', content: prompt }],
+  max_tokens: maxTokens ?? 2048,
+  temperature: temp ?? 0.7,
+});
+
+/**
  * AI client implementation for querying Anthropic Claude models.
  */
 export class AnthropicAIClient implements AIClient {
@@ -29,19 +66,13 @@ export class AnthropicAIClient implements AIClient {
    * @returns The generated response string.
    */
   async getCompletion(prompt: string): Promise<string> {
-    let url = this.config.baseUrl!;
-    if (url.endsWith('/v1') || url.endsWith('/v1/')) {
-      url = url.replace(/\/$/, '') + '/messages';
-    } else if (!url.includes('/messages')) {
-      url = url.replace(/\/$/, '') + '/messages';
-    }
-
-    const body = {
-      model: this.config.model,
-      messages: [{ role: 'user', content: prompt }],
-      max_tokens: this.config.maxTokens ?? 2048,
-      temperature: this.config.temperature ?? 0.7,
-    };
+    const url = formatAnthropicUrl(this.config.baseUrl);
+    const body = buildAnthropicBody(
+      this.config.model,
+      prompt,
+      this.config.temperature,
+      this.config.maxTokens,
+    );
 
     const res = await fetch(url, {
       method: 'POST',

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -1,0 +1,64 @@
+import { AIClient } from './types';
+import { AIProviderConfig } from '../config/schema';
+
+/**
+ * AI client implementation for querying Anthropic Claude models.
+ */
+export class AnthropicAIClient implements AIClient {
+  readonly name = 'anthropic';
+  private config!: AIProviderConfig;
+
+  /**
+   * Configures the client, ensuring the Anthropic API key is provided.
+   * @param config The provider configuration.
+   */
+  async configure(config: AIProviderConfig): Promise<void> {
+    this.config = {
+      ...config,
+      baseUrl: config.baseUrl ?? 'https://api.anthropic.com/v1/messages',
+      model: config.model || 'claude-3-5-sonnet-latest',
+    };
+    if (!this.config.password) {
+      throw new Error('API key (password) is required for anthropic provider');
+    }
+  }
+
+  /**
+   * Sends a message request to the Anthropic messages API.
+   * @param prompt The string prompt.
+   * @returns The generated response string.
+   */
+  async getCompletion(prompt: string): Promise<string> {
+    let url = this.config.baseUrl!;
+    if (url.endsWith('/v1') || url.endsWith('/v1/')) {
+      url = url.replace(/\/$/, '') + '/messages';
+    } else if (!url.includes('/messages')) {
+      url = url.replace(/\/$/, '') + '/messages';
+    }
+
+    const body = {
+      model: this.config.model,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: this.config.maxTokens ?? 2048,
+      temperature: this.config.temperature ?? 0.7,
+    };
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.config.password!,
+        'anthropic-version': '2023-06-01',
+        ...this.config.customHeaders,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Anthropic API call failed with status ${res.status}: ${res.statusText}`);
+    }
+
+    const data: any = await res.json();
+    return data.content?.[0]?.text || '';
+  }
+}

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -20,22 +20,19 @@ const formatAnthropicUrl = (baseUrl?: string): string => {
 
 /**
  * Builds the Anthropic payload body.
- * @param model Model name.
- * @param prompt Prompt text.
- * @param temp Temperature.
- * @param maxTokens MaxTokens.
+ * @param params Option parameters for the Anthropic payload.
  * @returns Payload body object.
  */
-const buildAnthropicBody = (
-  model: string,
-  prompt: string,
-  temp?: number,
-  maxTokens?: number,
-) => ({
-  model,
-  messages: [{ role: 'user', content: prompt }],
-  max_tokens: maxTokens ?? 2048,
-  temperature: temp ?? 0.7,
+const buildAnthropicBody = (params: {
+  model: string;
+  prompt: string;
+  temp?: number;
+  maxTokens?: number;
+}) => ({
+  model: params.model,
+  messages: [{ role: 'user', content: params.prompt }],
+  max_tokens: params.maxTokens ?? 2048,
+  temperature: params.temp ?? 0.7,
 });
 
 /**
@@ -67,12 +64,12 @@ export class AnthropicAIClient implements AIClient {
    */
   async getCompletion(prompt: string): Promise<string> {
     const url = formatAnthropicUrl(this.config.baseUrl);
-    const body = buildAnthropicBody(
-      this.config.model,
+    const body = buildAnthropicBody({
+      model: this.config.model,
       prompt,
-      this.config.temperature,
-      this.config.maxTokens,
-    );
+      temp: this.config.temperature,
+      maxTokens: this.config.maxTokens,
+    });
 
     const res = await fetch(url, {
       method: 'POST',

--- a/src/ai/custom-rest.ts
+++ b/src/ai/custom-rest.ts
@@ -1,0 +1,61 @@
+import { AIClient } from './types';
+import { AIProviderConfig } from '../config/schema';
+
+/**
+ * AI client implementation sending prompts to a configurable REST endpoint.
+ */
+export class CustomRestAIClient implements AIClient {
+  readonly name = 'customrest';
+  private config!: AIProviderConfig;
+
+  /**
+   * Configures the client, ensuring a baseUrl is specified.
+   * @param config The provider configuration.
+   */
+  async configure(config: AIProviderConfig): Promise<void> {
+    if (!config.baseUrl) {
+      throw new Error('baseUrl is required for customrest provider');
+    }
+    this.config = config;
+  }
+
+  /**
+   * Sends prompt data to the custom REST API endpoint.
+   * @param prompt The string prompt.
+   * @returns The resolved completion response.
+   */
+  async getCompletion(prompt: string): Promise<string> {
+    const url = this.config.baseUrl!;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.config.customHeaders,
+    };
+
+    if (this.config.password) {
+      headers['Authorization'] = `Bearer ${this.config.password}`;
+    }
+
+    const body = {
+      prompt,
+      model: this.config.model,
+      temperature: this.config.temperature ?? 0.7,
+      topP: this.config.topP ?? 1,
+      topK: this.config.topK ?? 50,
+      maxTokens: this.config.maxTokens ?? 2048,
+    };
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Custom REST API call failed with status ${res.status}: ${res.statusText}`);
+    }
+
+    const data: any = await res.json();
+    // Support common JSON response fields for simple prompt completions
+    return data.completion || data.response || data.text || JSON.stringify(data);
+  }
+}

--- a/src/ai/factory.ts
+++ b/src/ai/factory.ts
@@ -1,0 +1,47 @@
+import { AIClient } from './types';
+import { OpenAIAIClient } from './openai';
+import { AnthropicAIClient } from './anthropic';
+import { OllamaAIClient } from './ollama';
+import { CustomRestAIClient } from './custom-rest';
+import { NoopAIClient } from './noop';
+import { getAIConfig } from '../config/store';
+
+/**
+ * Instantiates and configures the appropriate AIClient based on the backend name.
+ * Looks up stored configuration credentials.
+ * @param backendName The name of the AI provider backend (e.g. 'openai', 'ollama').
+ * @returns Instantiated and configured AIClient.
+ */
+export async function createAIClient(backendName: string): Promise<AIClient> {
+  const aiConfig = getAIConfig();
+  const providerConfig = aiConfig.providers.find(
+    (p) => p.name.toLowerCase() === backendName.toLowerCase(),
+  );
+
+  let client: AIClient;
+
+  switch (backendName.toLowerCase()) {
+    case 'openai':
+      client = new OpenAIAIClient();
+      break;
+    case 'anthropic':
+      client = new AnthropicAIClient();
+      break;
+    case 'ollama':
+      client = new OllamaAIClient();
+      break;
+    case 'customrest':
+    case 'custom-rest':
+      client = new CustomRestAIClient();
+      break;
+    case 'noop':
+      client = new NoopAIClient();
+      break;
+    default:
+      throw new Error(`Unsupported AI provider: ${backendName}`);
+  }
+
+  const activeConfig = providerConfig || { name: backendName, model: '' };
+  await client.configure(activeConfig);
+  return client;
+}

--- a/src/ai/factory.ts
+++ b/src/ai/factory.ts
@@ -6,6 +6,15 @@ import { CustomRestAIClient } from './custom-rest';
 import { NoopAIClient } from './noop';
 import { getAIConfig } from '../config/store';
 
+const CLIENT_MAPPING: Record<string, new () => AIClient> = {
+  openai: OpenAIAIClient,
+  anthropic: AnthropicAIClient,
+  ollama: OllamaAIClient,
+  customrest: CustomRestAIClient,
+  'custom-rest': CustomRestAIClient,
+  noop: NoopAIClient,
+};
+
 /**
  * Instantiates and configures the appropriate AIClient based on the backend name.
  * Looks up stored configuration credentials.
@@ -18,29 +27,12 @@ export async function createAIClient(backendName: string): Promise<AIClient> {
     (p) => p.name.toLowerCase() === backendName.toLowerCase(),
   );
 
-  let client: AIClient;
-
-  switch (backendName.toLowerCase()) {
-    case 'openai':
-      client = new OpenAIAIClient();
-      break;
-    case 'anthropic':
-      client = new AnthropicAIClient();
-      break;
-    case 'ollama':
-      client = new OllamaAIClient();
-      break;
-    case 'customrest':
-    case 'custom-rest':
-      client = new CustomRestAIClient();
-      break;
-    case 'noop':
-      client = new NoopAIClient();
-      break;
-    default:
-      throw new Error(`Unsupported AI provider: ${backendName}`);
+  const ClientClass = CLIENT_MAPPING[backendName.toLowerCase()];
+  if (!ClientClass) {
+    throw new Error(`Unsupported AI provider: ${backendName}`);
   }
 
+  const client = new ClientClass();
   const activeConfig = providerConfig || { name: backendName, model: '' };
   await client.configure(activeConfig);
   return client;

--- a/src/ai/noop.ts
+++ b/src/ai/noop.ts
@@ -1,0 +1,26 @@
+import { AIClient } from './types';
+import { AIProviderConfig } from '../config/schema';
+
+/**
+ * AI client implementation for testing purposes returning deterministic responses.
+ */
+export class NoopAIClient implements AIClient {
+  readonly name = 'noop';
+
+  /**
+   * Configures the Noop client.
+   * @param config The provider configuration.
+   */
+  async configure(config: AIProviderConfig): Promise<void> {
+    // No-op
+  }
+
+  /**
+   * Generates a deterministic test completion.
+   * @param prompt The string prompt.
+   * @returns A fixed response string.
+   */
+  async getCompletion(prompt: string): Promise<string> {
+    return 'noop completion explanation';
+  }
+}

--- a/src/ai/ollama.ts
+++ b/src/ai/ollama.ts
@@ -1,0 +1,62 @@
+import { AIClient } from './types';
+import { AIProviderConfig } from '../config/schema';
+
+/**
+ * AI client implementation for querying local Ollama models.
+ */
+export class OllamaAIClient implements AIClient {
+  readonly name = 'ollama';
+  private config!: AIProviderConfig;
+
+  /**
+   * Configures the client, defaulting base url to localhost if unspecified.
+   * @param config The provider configuration.
+   */
+  async configure(config: AIProviderConfig): Promise<void> {
+    this.config = {
+      ...config,
+      baseUrl: config.baseUrl ?? 'http://localhost:11434',
+      model: config.model || 'llama3.1',
+    };
+  }
+
+  /**
+   * Sends a completion request to local Ollama generate API.
+   * @param prompt The string prompt.
+   * @returns The generated response string.
+   */
+  async getCompletion(prompt: string): Promise<string> {
+    let url = this.config.baseUrl!;
+    if (!url.endsWith('/api/generate')) {
+      url = url.replace(/\/$/, '') + '/api/generate';
+    }
+
+    const body = {
+      model: this.config.model,
+      prompt,
+      stream: false,
+      options: {
+        temperature: this.config.temperature ?? 0.7,
+        top_p: this.config.topP ?? 1,
+        top_k: this.config.topK ?? 50,
+        num_predict: this.config.maxTokens ?? 2048,
+      },
+    };
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.config.customHeaders,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Ollama API call failed with status ${res.status}: ${res.statusText}`);
+    }
+
+    const data: any = await res.json();
+    return data.response;
+  }
+}

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -2,6 +2,46 @@ import { AIClient } from './types';
 import { AIProviderConfig } from '../config/schema';
 
 /**
+ * Formats the standard OpenAI URL based on user custom base url configuration.
+ * @param baseUrl User configured base URL or undefined.
+ * @returns Formatted completions URL.
+ */
+const formatOpenAIUrl = (baseUrl?: string): string => {
+  const base = baseUrl || 'https://api.openai.com/v1/chat/completions';
+  const url = base.replace(/\/$/, '');
+  if (url.endsWith('/v1')) {
+    return `${url}/chat/completions`;
+  }
+  if (!url.includes('/chat/completions')) {
+    return `${url}/chat/completions`;
+  }
+  return url;
+};
+
+/**
+ * Builds the OpenAI payload body.
+ * @param model Model name.
+ * @param prompt Prompt text.
+ * @param temp Temperature.
+ * @param topP TopP.
+ * @param maxTokens MaxTokens.
+ * @returns Payload body object.
+ */
+const buildOpenAIBody = (
+  model: string,
+  prompt: string,
+  temp?: number,
+  topP?: number,
+  maxTokens?: number,
+) => ({
+  model,
+  messages: [{ role: 'user', content: prompt }],
+  temperature: temp ?? 0.7,
+  top_p: topP ?? 1,
+  max_tokens: maxTokens ?? 2048,
+});
+
+/**
  * AI client implementation for querying OpenAI compatible APIs.
  */
 export class OpenAIAIClient implements AIClient {
@@ -29,26 +69,20 @@ export class OpenAIAIClient implements AIClient {
    * @returns The generated response string.
    */
   async getCompletion(prompt: string): Promise<string> {
-    let url = this.config.baseUrl!;
-    if (url.endsWith('/v1') || url.endsWith('/v1/')) {
-      url = url.replace(/\/$/, '') + '/chat/completions';
-    } else if (!url.includes('/chat/completions')) {
-      url = url.replace(/\/$/, '') + '/chat/completions';
-    }
-
-    const body = {
-      model: this.config.model,
-      messages: [{ role: 'user', content: prompt }],
-      temperature: this.config.temperature ?? 0.7,
-      top_p: this.config.topP ?? 1,
-      max_tokens: this.config.maxTokens ?? 2048,
-    };
+    const url = formatOpenAIUrl(this.config.baseUrl);
+    const body = buildOpenAIBody(
+      this.config.model,
+      prompt,
+      this.config.temperature,
+      this.config.topP,
+      this.config.maxTokens,
+    );
 
     const res = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.config.password}`,
+        Authorization: `Bearer ${this.config.password}`,
         ...this.config.customHeaders,
       },
       body: JSON.stringify(body),

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -1,0 +1,64 @@
+import { AIClient } from './types';
+import { AIProviderConfig } from '../config/schema';
+
+/**
+ * AI client implementation for querying OpenAI compatible APIs.
+ */
+export class OpenAIAIClient implements AIClient {
+  readonly name = 'openai';
+  private config!: AIProviderConfig;
+
+  /**
+   * Configures the client, ensuring the API key is set.
+   * @param config The provider configuration.
+   */
+  async configure(config: AIProviderConfig): Promise<void> {
+    this.config = {
+      ...config,
+      baseUrl: config.baseUrl ?? 'https://api.openai.com/v1/chat/completions',
+      model: config.model || 'gpt-4o',
+    };
+    if (!this.config.password) {
+      throw new Error('API key (password) is required for openai provider');
+    }
+  }
+
+  /**
+   * Sends a chat completion query to the OpenAI API.
+   * @param prompt The string prompt.
+   * @returns The generated response string.
+   */
+  async getCompletion(prompt: string): Promise<string> {
+    let url = this.config.baseUrl!;
+    if (url.endsWith('/v1') || url.endsWith('/v1/')) {
+      url = url.replace(/\/$/, '') + '/chat/completions';
+    } else if (!url.includes('/chat/completions')) {
+      url = url.replace(/\/$/, '') + '/chat/completions';
+    }
+
+    const body = {
+      model: this.config.model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: this.config.temperature ?? 0.7,
+      top_p: this.config.topP ?? 1,
+      max_tokens: this.config.maxTokens ?? 2048,
+    };
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.config.password}`,
+        ...this.config.customHeaders,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`OpenAI API call failed with status ${res.status}: ${res.statusText}`);
+    }
+
+    const data: any = await res.json();
+    return data.choices?.[0]?.message?.content || '';
+  }
+}

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -20,25 +20,21 @@ const formatOpenAIUrl = (baseUrl?: string): string => {
 
 /**
  * Builds the OpenAI payload body.
- * @param model Model name.
- * @param prompt Prompt text.
- * @param temp Temperature.
- * @param topP TopP.
- * @param maxTokens MaxTokens.
+ * @param params Option parameters for the OpenAI payload.
  * @returns Payload body object.
  */
-const buildOpenAIBody = (
-  model: string,
-  prompt: string,
-  temp?: number,
-  topP?: number,
-  maxTokens?: number,
-) => ({
-  model,
-  messages: [{ role: 'user', content: prompt }],
-  temperature: temp ?? 0.7,
-  top_p: topP ?? 1,
-  max_tokens: maxTokens ?? 2048,
+const buildOpenAIBody = (params: {
+  model: string;
+  prompt: string;
+  temp?: number;
+  topP?: number;
+  maxTokens?: number;
+}) => ({
+  model: params.model,
+  messages: [{ role: 'user', content: params.prompt }],
+  temperature: params.temp ?? 0.7,
+  top_p: params.topP ?? 1,
+  max_tokens: params.maxTokens ?? 2048,
 });
 
 /**
@@ -70,13 +66,13 @@ export class OpenAIAIClient implements AIClient {
    */
   async getCompletion(prompt: string): Promise<string> {
     const url = formatOpenAIUrl(this.config.baseUrl);
-    const body = buildOpenAIBody(
-      this.config.model,
+    const body = buildOpenAIBody({
+      model: this.config.model,
       prompt,
-      this.config.temperature,
-      this.config.topP,
-      this.config.maxTokens,
-    );
+      temp: this.config.temperature,
+      topP: this.config.topP,
+      maxTokens: this.config.maxTokens,
+    });
 
     const res = await fetch(url, {
       method: 'POST',

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,0 +1,28 @@
+import { AIProviderConfig } from '../config/schema';
+
+/**
+ * Interface representing a standardized AI provider client.
+ */
+export interface AIClient {
+  /**
+   * The name of the backend provider.
+   */
+  name: string;
+
+  /**
+   * Configures the client with the specified credentials and settings.
+   * @param config The AI provider config options.
+   */
+  configure(config: AIProviderConfig): Promise<void>;
+
+  /**
+   * Generates a text completion based on the given prompt.
+   * @param prompt The string prompt to send to the provider.
+   */
+  getCompletion(prompt: string): Promise<string>;
+
+  /**
+   * Optional clean up operation when the client is closed.
+   */
+  close?(): Promise<void>;
+}

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -5,6 +5,17 @@ import { type AIProviderConfig } from '../config/schema';
 
 const VALID_BACKENDS = new Set(['openai', 'ollama', 'anthropic', 'noop', 'customrest']);
 
+const DEFAULT_MODELS: Record<string, string> = {
+  openai: 'gpt-4o',
+  anthropic: 'claude-3-5-sonnet-latest',
+  ollama: 'llama3.1',
+};
+
+interface ProviderContext {
+  backend: string;
+  idx: number;
+}
+
 /**
  * Helper to collect multiple custom header flags from the CLI options into an array.
  * @param value The newly passed header.
@@ -12,22 +23,6 @@ const VALID_BACKENDS = new Set(['openai', 'ollama', 'anthropic', 'noop', 'custom
  * @returns Array containing all collected headers.
  */
 const collectHeaders = (value: string, previous: string[]): string[] => [...previous, value];
-
-/**
- * Validates the backend name against the supported list.
- * @param backend The provider backend name.
- * @returns The normalized backend name.
- * @throws Error if backend is invalid.
- */
-const validateBackend = (backend: string): string => {
-  const normalized = backend.toLowerCase();
-  if (!VALID_BACKENDS.has(normalized)) {
-    throw new Error(
-      `Unsupported backend "${backend}". Supported: ${Array.from(VALID_BACKENDS).join(', ')}`,
-    );
-  }
-  return normalized;
-};
 
 /**
  * Parses raw Key=Value header strings into a Record object.
@@ -49,77 +44,119 @@ const parseCustomHeaders = (headers: string[]): Record<string, string> => {
 
 /**
  * Masks secrets/API keys to avoid leaking them in plain text display.
- * @param secret Stored secret key.
+ * @param provider The AI provider configuration.
  * @returns Masked representation.
  */
-const maskSecret = (secret?: string): string => {
+const getMaskedSecret = (provider: AIProviderConfig): string => {
+  const secret = provider.password;
   if (!secret) return '(not set)';
   if (secret.length <= 8) return '********';
   return `${secret.substring(0, 4)}...${secret.substring(secret.length - 4)}`;
 };
 
 /**
- * Resolves default model name for a provider backend if not explicitly provided.
- * @param backend Normalized backend name.
- * @returns The default model name.
+ * Resolves the backend name and its configuration index in the provider list.
+ * Exits with error status if the backend is not configured or unsupported.
+ * @param params Object containing target name and the providers list.
+ * @returns Resolved ProviderContext or null if error occurred.
  */
-const getDefaultModel = (backend: string): string => {
-  if (backend === 'openai') return 'gpt-4o';
-  if (backend === 'anthropic') return 'claude-3-5-sonnet-latest';
-  if (backend === 'ollama') return 'llama3.1';
-  return 'default';
-};
-
-/**
- * Adds a new AI provider to the store.
- * @param options CLI parsed option flags.
- */
-const handleAuthAdd = (options: any): void => {
-  let backend: string;
-  try {
-    backend = validateBackend(options.backend || 'openai');
-  } catch (err: any) {
-    console.error(chalk.red(`Error: ${err.message}`));
-    process.exitCode = 1;
-    return;
-  }
-
-  const aiConfig = getAIConfig();
-  const exists = aiConfig.providers.some((p) => p.name.toLowerCase() === backend);
-  if (exists) {
+const resolveProviderContext = (params: {
+  name: string;
+  providers: AIProviderConfig[];
+}): ProviderContext | null => {
+  const { name, providers } = params;
+  const normalized = name.toLowerCase();
+  if (!VALID_BACKENDS.has(normalized)) {
     console.error(
       chalk.red(
-        `Error: Provider "${backend}" is already configured. Use "kdm auth update ${backend}" instead.`,
+        `Error: Unsupported backend "${name}". Supported: ${Array.from(VALID_BACKENDS).join(', ')}`,
       ),
     );
     process.exitCode = 1;
-    return;
+    return null;
   }
 
-  const model = options.model || getDefaultModel(backend);
-  const customHeaders = options.customHeader?.length
-    ? parseCustomHeaders(options.customHeader)
-    : undefined;
-
-  const provider: AIProviderConfig = {
-    name: backend,
-    model,
-    password: options.password,
-    baseUrl: options.baseurl,
-    temperature: options.temperature ? Number.parseFloat(options.temperature) : 0.7,
-    topP: options.topp ? Number.parseFloat(options.topp) : 1,
-    topK: options.topk ? Number.parseInt(options.topk, 10) : 50,
-    maxTokens: options.maxtokens ? Number.parseInt(options.maxtokens, 10) : 2048,
-    customHeaders,
-  };
-
-  aiConfig.providers.push(provider);
-  if (!aiConfig.defaultProvider) {
-    aiConfig.defaultProvider = backend;
+  const idx = providers.findIndex((p) => p.name.toLowerCase() === normalized);
+  if (idx === -1) {
+    console.error(chalk.red(`Error: AI provider "${name}" is not configured.`));
+    process.exitCode = 1;
+    return null;
   }
 
-  setAIConfig(aiConfig);
-  console.log(chalk.green(`Successfully added AI provider "${backend}".`));
+  return { backend: normalized, idx };
+};
+
+/**
+ * Validates and resolves the backend name from CLI options.
+ * @param options CLI parsed options.
+ * @returns Resolved backend name or null.
+ */
+const resolveNewBackend = (options: any): string | null => {
+  const backend = (options.backend || 'openai').toLowerCase();
+  if (!VALID_BACKENDS.has(backend)) {
+    console.error(
+      chalk.red(
+        `Error: Unsupported backend "${options.backend}". Supported: ${Array.from(VALID_BACKENDS).join(', ')}`,
+      ),
+    );
+    process.exitCode = 1;
+    return null;
+  }
+  return backend;
+};
+
+/**
+ * Ensures provider does not already exist in the list.
+ * @param params Object containing target name and providers list.
+ * @returns true if not configured.
+ */
+const ensureProviderNotExists = (params: {
+  name: string;
+  providers: AIProviderConfig[];
+}): boolean => {
+  const { name, providers } = params;
+  if (providers.some((p) => p.name.toLowerCase() === name)) {
+    console.error(
+      chalk.red(
+        `Error: Provider "${name}" is already configured. Use "kdm auth update ${name}" instead.`,
+      ),
+    );
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Updates option header configuration parameters.
+ * @param provider Config to update.
+ * @param options CLI flags.
+ */
+const updateHeaders = (provider: AIProviderConfig, options: any): void => {
+  const customHeader = options.customHeader;
+  if (customHeader && customHeader.length > 0) {
+    provider.customHeaders = parseCustomHeaders(customHeader);
+  }
+};
+
+/**
+ * Updates option numeric configuration parameters.
+ * @param provider Config to update.
+ * @param options CLI flags.
+ */
+const updateNumericFields = (provider: AIProviderConfig, options: any): void => {
+  if (options.temperature !== undefined) {
+    provider.temperature = Number.parseFloat(options.temperature);
+  }
+  if (options.topp !== undefined) {
+    provider.topP = Number.parseFloat(options.topp);
+  }
+  if (options.topk !== undefined) {
+    provider.topK = Number.parseInt(options.topk, 10);
+  }
+  if (options.maxtokens !== undefined) {
+    provider.maxTokens = Number.parseInt(options.maxtokens, 10);
+  }
 };
 
 /**
@@ -131,17 +168,61 @@ const assignProviderUpdateOptions = (provider: AIProviderConfig, options: any): 
   if (options.model) provider.model = options.model;
   if (options.password !== undefined) provider.password = options.password;
   if (options.baseurl !== undefined) provider.baseUrl = options.baseurl;
-  if (options.temperature !== undefined) {
-    provider.temperature = Number.parseFloat(options.temperature);
-  }
-  if (options.topp !== undefined) provider.topP = Number.parseFloat(options.topp);
-  if (options.topk !== undefined) provider.topK = Number.parseInt(options.topk, 10);
-  if (options.maxtokens !== undefined) {
-    provider.maxTokens = Number.parseInt(options.maxtokens, 10);
-  }
-  if (options.customHeader?.length) {
-    provider.customHeaders = parseCustomHeaders(options.customHeader);
-  }
+  updateNumericFields(provider, options);
+  updateHeaders(provider, options);
+};
+
+/**
+ * Helper to update configuration state and print success messaging.
+ * @param params Object containing backend name, mutate action and success message structure.
+ */
+const modifyProviderConfig = (params: {
+  backend: string;
+  mutate: (config: ReturnType<typeof getAIConfig>, idx: number, name: string) => void;
+  message: string;
+}): void => {
+  const { backend, mutate, message } = params;
+  const aiConfig = getAIConfig();
+  const ctx = resolveProviderContext({ name: backend, providers: aiConfig.providers });
+  if (!ctx) return;
+
+  mutate(aiConfig, ctx.idx, ctx.backend);
+  setAIConfig(aiConfig);
+  console.log(chalk.green(message.replace('%s', ctx.backend)));
+};
+
+/**
+ * Adds a new AI provider to the store.
+ * @param options CLI parsed option flags.
+ */
+const handleAuthAdd = (options: any): void => {
+  const backend = resolveNewBackend(options);
+  if (!backend) return;
+
+  const aiConfig = getAIConfig();
+  if (!ensureProviderNotExists({ name: backend, providers: aiConfig.providers })) return;
+
+  const customHeaders = options.customHeader?.length
+    ? parseCustomHeaders(options.customHeader)
+    : undefined;
+
+  const provider: AIProviderConfig = {
+    name: backend,
+    model: options.model || DEFAULT_MODELS[backend] || 'default',
+    password: options.password,
+    baseUrl: options.baseurl,
+    temperature: options.temperature ? Number.parseFloat(options.temperature) : 0.7,
+    topP: options.topp ? Number.parseFloat(options.topp) : 1,
+    topK: options.topk ? Number.parseInt(options.topk, 10) : 50,
+    maxTokens: options.maxtokens ? Number.parseInt(options.maxtokens, 10) : 2048,
+    customHeaders,
+  };
+
+  aiConfig.providers.push(provider);
+  aiConfig.defaultProvider = aiConfig.defaultProvider || backend;
+
+  setAIConfig(aiConfig);
+  console.log(chalk.green(`Successfully added AI provider "${backend}".`));
 };
 
 /**
@@ -150,33 +231,11 @@ const assignProviderUpdateOptions = (provider: AIProviderConfig, options: any): 
  * @param options CLI parsed option flags.
  */
 const handleAuthUpdate = (backend: string, options: any): void => {
-  let normalizedBackend: string;
-  try {
-    normalizedBackend = validateBackend(backend);
-  } catch (err: any) {
-    console.error(chalk.red(`Error: ${err.message}`));
-    process.exitCode = 1;
-    return;
-  }
-
-  const aiConfig = getAIConfig();
-  const idx = aiConfig.providers.findIndex(
-    (p) => p.name.toLowerCase() === normalizedBackend,
-  );
-
-  if (idx === -1) {
-    console.error(
-      chalk.red(
-        `Error: AI provider "${backend}" is not configured. Use "kdm auth add" to add it first.`,
-      ),
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  assignProviderUpdateOptions(aiConfig.providers[idx], options);
-  setAIConfig(aiConfig);
-  console.log(chalk.green(`Successfully updated AI provider "${normalizedBackend}".`));
+  modifyProviderConfig({
+    backend,
+    mutate: (config, idx) => assignProviderUpdateOptions(config.providers[idx], options),
+    message: 'Successfully updated AI provider "%s".',
+  });
 };
 
 /**
@@ -195,7 +254,7 @@ const handleAuthList = (): void => {
     const defaultMarker = isDefault ? chalk.green(' (default)') : '';
     console.log(`- ${chalk.blue.bold(p.name)}${defaultMarker}:`);
     console.log(`    Model:       ${p.model}`);
-    console.log(`    Password:    ${maskSecret(p.password)}`);
+    console.log(`    Password:    ${getMaskedSecret(p)}`);
     console.log(`    Base URL:    ${p.baseUrl || '(default)'}`);
     console.log(`    Temperature: ${p.temperature ?? 0.7}`);
     console.log(`    TopP:        ${p.topP ?? 1}`);
@@ -209,30 +268,13 @@ const handleAuthList = (): void => {
  * @param backend Name of the backend.
  */
 const handleAuthDefault = (backend: string): void => {
-  let normalizedBackend: string;
-  try {
-    normalizedBackend = validateBackend(backend);
-  } catch (err: any) {
-    console.error(chalk.red(`Error: ${err.message}`));
-    process.exitCode = 1;
-    return;
-  }
-
-  const aiConfig = getAIConfig();
-  const exists = aiConfig.providers.some((p) => p.name.toLowerCase() === normalizedBackend);
-  if (!exists) {
-    console.error(
-      chalk.red(
-        `Error: AI provider "${backend}" is not configured. Configure it first using "kdm auth add".`,
-      ),
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  aiConfig.defaultProvider = normalizedBackend;
-  setAIConfig(aiConfig);
-  console.log(chalk.green(`Successfully set default AI provider to "${normalizedBackend}".`));
+  modifyProviderConfig({
+    backend,
+    mutate: (config, _, name) => {
+      config.defaultProvider = name;
+    },
+    message: 'Successfully set default AI provider to "%s".',
+  });
 };
 
 /**
@@ -240,33 +282,17 @@ const handleAuthDefault = (backend: string): void => {
  * @param backend Name of the backend.
  */
 const handleAuthRemove = (backend: string): void => {
-  let normalizedBackend: string;
-  try {
-    normalizedBackend = validateBackend(backend);
-  } catch (err: any) {
-    console.error(chalk.red(`Error: ${err.message}`));
-    process.exitCode = 1;
-    return;
-  }
-
-  const aiConfig = getAIConfig();
-  const exists = aiConfig.providers.some((p) => p.name.toLowerCase() === normalizedBackend);
-  if (!exists) {
-    console.error(chalk.red(`Error: AI provider "${backend}" is not configured.`));
-    process.exitCode = 1;
-    return;
-  }
-
-  aiConfig.providers = aiConfig.providers.filter(
-    (p) => p.name.toLowerCase() !== normalizedBackend,
-  );
-
-  if (aiConfig.defaultProvider?.toLowerCase() === normalizedBackend) {
-    aiConfig.defaultProvider = aiConfig.providers.length > 0 ? aiConfig.providers[0].name : undefined;
-  }
-
-  setAIConfig(aiConfig);
-  console.log(chalk.green(`Successfully removed AI provider "${normalizedBackend}".`));
+  modifyProviderConfig({
+    backend,
+    mutate: (config, _, name) => {
+      config.providers = config.providers.filter((p) => p.name.toLowerCase() !== name);
+      if (config.defaultProvider?.toLowerCase() === name) {
+        config.defaultProvider =
+          config.providers.length > 0 ? config.providers[0].name : undefined;
+      }
+    },
+    message: 'Successfully removed AI provider "%s".',
+  });
 };
 
 /**
@@ -296,7 +322,12 @@ export const registerAuthCommand = (program: Command): void => {
     .option('--topp <topp>', 'Top-P value')
     .option('--topk <topk>', 'Top-K value')
     .option('--maxtokens <maxtokens>', 'Maximum tokens to generate')
-    .option('--custom-header <header>', 'Custom request headers in Key=Value format', collectHeaders, [])
+    .option(
+      '--custom-header <header>',
+      'Custom request headers in Key=Value format',
+      collectHeaders,
+      [],
+    )
     .action(handleAuthAdd);
 
   auth
@@ -324,6 +355,11 @@ export const registerAuthCommand = (program: Command): void => {
     .option('--topp <topp>', 'Top-P value')
     .option('--topk <topk>', 'Top-K value')
     .option('--maxtokens <maxtokens>', 'Maximum tokens to generate')
-    .option('--custom-header <header>', 'Custom request headers in Key=Value format', collectHeaders, [])
+    .option(
+      '--custom-header <header>',
+      'Custom request headers in Key=Value format',
+      collectHeaders,
+      [],
+    )
     .action(handleAuthUpdate);
 };

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,0 +1,329 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getAIConfig, setAIConfig } from '../config/store';
+import { type AIProviderConfig } from '../config/schema';
+
+const VALID_BACKENDS = new Set(['openai', 'ollama', 'anthropic', 'noop', 'customrest']);
+
+/**
+ * Helper to collect multiple custom header flags from the CLI options into an array.
+ * @param value The newly passed header.
+ * @param previous Accumulator list of previously collected headers.
+ * @returns Array containing all collected headers.
+ */
+const collectHeaders = (value: string, previous: string[]): string[] => [...previous, value];
+
+/**
+ * Validates the backend name against the supported list.
+ * @param backend The provider backend name.
+ * @returns The normalized backend name.
+ * @throws Error if backend is invalid.
+ */
+const validateBackend = (backend: string): string => {
+  const normalized = backend.toLowerCase();
+  if (!VALID_BACKENDS.has(normalized)) {
+    throw new Error(
+      `Unsupported backend "${backend}". Supported: ${Array.from(VALID_BACKENDS).join(', ')}`,
+    );
+  }
+  return normalized;
+};
+
+/**
+ * Parses raw Key=Value header strings into a Record object.
+ * @param headers String list of headers.
+ * @returns Formatted headers record.
+ */
+const parseCustomHeaders = (headers: string[]): Record<string, string> => {
+  const result: Record<string, string> = {};
+  for (const h of headers) {
+    const parts = h.split('=');
+    if (parts.length >= 2) {
+      const key = parts[0].trim();
+      const val = parts.slice(1).join('=').trim();
+      result[key] = val;
+    }
+  }
+  return result;
+};
+
+/**
+ * Masks secrets/API keys to avoid leaking them in plain text display.
+ * @param secret Stored secret key.
+ * @returns Masked representation.
+ */
+const maskSecret = (secret?: string): string => {
+  if (!secret) return '(not set)';
+  if (secret.length <= 8) return '********';
+  return `${secret.substring(0, 4)}...${secret.substring(secret.length - 4)}`;
+};
+
+/**
+ * Resolves default model name for a provider backend if not explicitly provided.
+ * @param backend Normalized backend name.
+ * @returns The default model name.
+ */
+const getDefaultModel = (backend: string): string => {
+  if (backend === 'openai') return 'gpt-4o';
+  if (backend === 'anthropic') return 'claude-3-5-sonnet-latest';
+  if (backend === 'ollama') return 'llama3.1';
+  return 'default';
+};
+
+/**
+ * Adds a new AI provider to the store.
+ * @param options CLI parsed option flags.
+ */
+const handleAuthAdd = (options: any): void => {
+  let backend: string;
+  try {
+    backend = validateBackend(options.backend || 'openai');
+  } catch (err: any) {
+    console.error(chalk.red(`Error: ${err.message}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const aiConfig = getAIConfig();
+  const exists = aiConfig.providers.some((p) => p.name.toLowerCase() === backend);
+  if (exists) {
+    console.error(
+      chalk.red(
+        `Error: Provider "${backend}" is already configured. Use "kdm auth update ${backend}" instead.`,
+      ),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const model = options.model || getDefaultModel(backend);
+  const customHeaders = options.customHeader?.length
+    ? parseCustomHeaders(options.customHeader)
+    : undefined;
+
+  const provider: AIProviderConfig = {
+    name: backend,
+    model,
+    password: options.password,
+    baseUrl: options.baseurl,
+    temperature: options.temperature ? Number.parseFloat(options.temperature) : 0.7,
+    topP: options.topp ? Number.parseFloat(options.topp) : 1,
+    topK: options.topk ? Number.parseInt(options.topk, 10) : 50,
+    maxTokens: options.maxtokens ? Number.parseInt(options.maxtokens, 10) : 2048,
+    customHeaders,
+  };
+
+  aiConfig.providers.push(provider);
+  if (!aiConfig.defaultProvider) {
+    aiConfig.defaultProvider = backend;
+  }
+
+  setAIConfig(aiConfig);
+  console.log(chalk.green(`Successfully added AI provider "${backend}".`));
+};
+
+/**
+ * Assigns non-undefined CLI flags to a provider configuration.
+ * @param provider Config to update.
+ * @param options CLI flags.
+ */
+const assignProviderUpdateOptions = (provider: AIProviderConfig, options: any): void => {
+  if (options.model) provider.model = options.model;
+  if (options.password !== undefined) provider.password = options.password;
+  if (options.baseurl !== undefined) provider.baseUrl = options.baseurl;
+  if (options.temperature !== undefined) {
+    provider.temperature = Number.parseFloat(options.temperature);
+  }
+  if (options.topp !== undefined) provider.topP = Number.parseFloat(options.topp);
+  if (options.topk !== undefined) provider.topK = Number.parseInt(options.topk, 10);
+  if (options.maxtokens !== undefined) {
+    provider.maxTokens = Number.parseInt(options.maxtokens, 10);
+  }
+  if (options.customHeader?.length) {
+    provider.customHeaders = parseCustomHeaders(options.customHeader);
+  }
+};
+
+/**
+ * Updates an existing AI provider in the store.
+ * @param backend Name of the backend to update.
+ * @param options CLI parsed option flags.
+ */
+const handleAuthUpdate = (backend: string, options: any): void => {
+  let normalizedBackend: string;
+  try {
+    normalizedBackend = validateBackend(backend);
+  } catch (err: any) {
+    console.error(chalk.red(`Error: ${err.message}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const aiConfig = getAIConfig();
+  const idx = aiConfig.providers.findIndex(
+    (p) => p.name.toLowerCase() === normalizedBackend,
+  );
+
+  if (idx === -1) {
+    console.error(
+      chalk.red(
+        `Error: AI provider "${backend}" is not configured. Use "kdm auth add" to add it first.`,
+      ),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  assignProviderUpdateOptions(aiConfig.providers[idx], options);
+  setAIConfig(aiConfig);
+  console.log(chalk.green(`Successfully updated AI provider "${normalizedBackend}".`));
+};
+
+/**
+ * Lists the configured AI providers.
+ */
+const handleAuthList = (): void => {
+  const aiConfig = getAIConfig();
+  if (aiConfig.providers.length === 0) {
+    console.log('No AI providers configured.');
+    return;
+  }
+
+  console.log(chalk.bold('Configured AI Providers:'));
+  aiConfig.providers.forEach((p) => {
+    const isDefault = aiConfig.defaultProvider?.toLowerCase() === p.name.toLowerCase();
+    const defaultMarker = isDefault ? chalk.green(' (default)') : '';
+    console.log(`- ${chalk.blue.bold(p.name)}${defaultMarker}:`);
+    console.log(`    Model:       ${p.model}`);
+    console.log(`    Password:    ${maskSecret(p.password)}`);
+    console.log(`    Base URL:    ${p.baseUrl || '(default)'}`);
+    console.log(`    Temperature: ${p.temperature ?? 0.7}`);
+    console.log(`    TopP:        ${p.topP ?? 1}`);
+    console.log(`    TopK:        ${p.topK ?? 50}`);
+    console.log(`    MaxTokens:   ${p.maxTokens ?? 2048}`);
+  });
+};
+
+/**
+ * Sets the default AI provider.
+ * @param backend Name of the backend.
+ */
+const handleAuthDefault = (backend: string): void => {
+  let normalizedBackend: string;
+  try {
+    normalizedBackend = validateBackend(backend);
+  } catch (err: any) {
+    console.error(chalk.red(`Error: ${err.message}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const aiConfig = getAIConfig();
+  const exists = aiConfig.providers.some((p) => p.name.toLowerCase() === normalizedBackend);
+  if (!exists) {
+    console.error(
+      chalk.red(
+        `Error: AI provider "${backend}" is not configured. Configure it first using "kdm auth add".`,
+      ),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  aiConfig.defaultProvider = normalizedBackend;
+  setAIConfig(aiConfig);
+  console.log(chalk.green(`Successfully set default AI provider to "${normalizedBackend}".`));
+};
+
+/**
+ * Removes an AI provider.
+ * @param backend Name of the backend.
+ */
+const handleAuthRemove = (backend: string): void => {
+  let normalizedBackend: string;
+  try {
+    normalizedBackend = validateBackend(backend);
+  } catch (err: any) {
+    console.error(chalk.red(`Error: ${err.message}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const aiConfig = getAIConfig();
+  const exists = aiConfig.providers.some((p) => p.name.toLowerCase() === normalizedBackend);
+  if (!exists) {
+    console.error(chalk.red(`Error: AI provider "${backend}" is not configured.`));
+    process.exitCode = 1;
+    return;
+  }
+
+  aiConfig.providers = aiConfig.providers.filter(
+    (p) => p.name.toLowerCase() !== normalizedBackend,
+  );
+
+  if (aiConfig.defaultProvider?.toLowerCase() === normalizedBackend) {
+    aiConfig.defaultProvider = aiConfig.providers.length > 0 ? aiConfig.providers[0].name : undefined;
+  }
+
+  setAIConfig(aiConfig);
+  console.log(chalk.green(`Successfully removed AI provider "${normalizedBackend}".`));
+};
+
+/**
+ * Registers the auth subcommands on the Commander program.
+ * @param program Commander program instance.
+ */
+export const registerAuthCommand = (program: Command): void => {
+  const auth = program
+    .command('auth')
+    .description('Manage AI provider authentication and credentials');
+
+  auth
+    .command('add')
+    .description('Add authentication details for an AI provider backend')
+    .option(
+      '-b, --backend <backend>',
+      'AI backend provider (openai, ollama, anthropic, noop, customrest)',
+      'openai',
+    )
+    .option(
+      '-m, --model <model>',
+      'AI model to use (defaults: openai=gpt-4o, anthropic=claude-3-5-sonnet-latest, ollama=llama3.1)',
+    )
+    .option('-p, --password <password>', 'API Key or password for the provider')
+    .option('-u, --baseurl <baseurl>', 'Custom API Base URL')
+    .option('-t, --temperature <temperature>', 'Sampling temperature')
+    .option('--topp <topp>', 'Top-P value')
+    .option('--topk <topk>', 'Top-K value')
+    .option('--maxtokens <maxtokens>', 'Maximum tokens to generate')
+    .option('--custom-header <header>', 'Custom request headers in Key=Value format', collectHeaders, [])
+    .action(handleAuthAdd);
+
+  auth
+    .command('list')
+    .description('List configured AI providers with masked secrets')
+    .action(handleAuthList);
+
+  auth
+    .command('default <backend>')
+    .description('Set the default AI provider backend')
+    .action(handleAuthDefault);
+
+  auth
+    .command('remove <backend>')
+    .description('Remove configuration for an AI provider backend')
+    .action(handleAuthRemove);
+
+  auth
+    .command('update <backend>')
+    .description('Update configuration details for an AI provider backend')
+    .option('-m, --model <model>', 'AI model to use')
+    .option('-p, --password <password>', 'API Key or password for the provider')
+    .option('-u, --baseurl <baseurl>', 'Custom API Base URL')
+    .option('-t, --temperature <temperature>', 'Sampling temperature')
+    .option('--topp <topp>', 'Top-P value')
+    .option('--topk <topk>', 'Top-K value')
+    .option('--maxtokens <maxtokens>', 'Maximum tokens to generate')
+    .option('--custom-header <header>', 'Custom request headers in Key=Value format', collectHeaders, [])
+    .action(handleAuthUpdate);
+};

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -140,11 +140,11 @@ const updateHeaders = (provider: AIProviderConfig, options: any): void => {
 };
 
 /**
- * Updates option numeric configuration parameters.
- * @param provider Config to update.
- * @param options CLI flags.
+ * Parses numeric option fields and populates them on the provider configuration.
+ * @param provider Configuration object.
+ * @param options User specified CLI options.
  */
-const updateNumericFields = (provider: AIProviderConfig, options: any): void => {
+const parseNumericFields = (provider: AIProviderConfig, options: any): void => {
   if (options.temperature !== undefined) {
     provider.temperature = Number.parseFloat(options.temperature);
   }
@@ -168,8 +168,57 @@ const assignProviderUpdateOptions = (provider: AIProviderConfig, options: any): 
   if (options.model) provider.model = options.model;
   if (options.password !== undefined) provider.password = options.password;
   if (options.baseurl !== undefined) provider.baseUrl = options.baseurl;
-  updateNumericFields(provider, options);
+  parseNumericFields(provider, options);
   updateHeaders(provider, options);
+};
+
+/**
+ * Parses options header configurations if set.
+ * @param customHeader Header flags array.
+ * @returns Header record or undefined.
+ */
+const parseHeadersOption = (customHeader?: string[]): Record<string, string> | undefined => {
+  if (customHeader && customHeader.length > 0) {
+    return parseCustomHeaders(customHeader);
+  }
+  return undefined;
+};
+
+/**
+ * Resolves the configuration model.
+ * @param backend Normalized backend name.
+ * @param modelOption User specified model name option.
+ * @returns Resolved model string.
+ */
+const resolveModel = (backend: string, modelOption?: string): string => {
+  return modelOption || DEFAULT_MODELS[backend] || 'default';
+};
+
+
+
+/**
+ * Builds the complete AIProviderConfig from inputs.
+ * @param params Object containing normalized name and options object.
+ * @returns Constructed AIProviderConfig.
+ */
+const buildProviderConfig = (params: {
+  backend: string;
+  options: any;
+}): AIProviderConfig => {
+  const { backend, options } = params;
+  const provider: AIProviderConfig = {
+    name: backend,
+    model: resolveModel(backend, options.model),
+    password: options.password,
+    baseUrl: options.baseurl,
+    temperature: 0.7,
+    topP: 1,
+    topK: 50,
+    maxTokens: 2048,
+    customHeaders: parseHeadersOption(options.customHeader),
+  };
+  parseNumericFields(provider, options);
+  return provider;
 };
 
 /**
@@ -202,23 +251,7 @@ const handleAuthAdd = (options: any): void => {
   const aiConfig = getAIConfig();
   if (!ensureProviderNotExists({ name: backend, providers: aiConfig.providers })) return;
 
-  const customHeaders = options.customHeader?.length
-    ? parseCustomHeaders(options.customHeader)
-    : undefined;
-
-  const provider: AIProviderConfig = {
-    name: backend,
-    model: options.model || DEFAULT_MODELS[backend] || 'default',
-    password: options.password,
-    baseUrl: options.baseurl,
-    temperature: options.temperature ? Number.parseFloat(options.temperature) : 0.7,
-    topP: options.topp ? Number.parseFloat(options.topp) : 1,
-    topK: options.topk ? Number.parseInt(options.topk, 10) : 50,
-    maxTokens: options.maxtokens ? Number.parseInt(options.maxtokens, 10) : 2048,
-    customHeaders,
-  };
-
-  aiConfig.providers.push(provider);
+  aiConfig.providers.push(buildProviderConfig({ backend, options }));
   aiConfig.defaultProvider = aiConfig.defaultProvider || backend;
 
   setAIConfig(aiConfig);

--- a/src/commands/filters.ts
+++ b/src/commands/filters.ts
@@ -1,0 +1,119 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getActiveFilters, setActiveFilters } from '../config/store';
+import { registry } from '../analyzers';
+
+const DEFAULT_FILTERS = ['Pod', 'Deployment', 'Service', 'PersistentVolumeClaim', 'Node'];
+
+/**
+ * Lists the configured active filters and the available inactive ones.
+ */
+const handleListFilters = (): void => {
+  const active = getActiveFilters();
+  const allAvailable = registry.list().map((a) => a.name);
+
+  const activeDisplay = active.length > 0 ? active : DEFAULT_FILTERS;
+  const inactiveDisplay = allAvailable.filter((name) => !activeDisplay.includes(name));
+
+  console.log(chalk.bold('Active filters:'));
+  if (activeDisplay.length > 0) {
+    activeDisplay.forEach((f) => console.log(`- ${f}`));
+  } else {
+    console.log('(none)');
+  }
+
+  console.log();
+  console.log(chalk.bold('Available but inactive filters:'));
+  if (inactiveDisplay.length > 0) {
+    inactiveDisplay.forEach((f) => console.log(`- ${f}`));
+  } else {
+    console.log('(none)');
+  }
+};
+
+/**
+ * Adds a filter name to the active filters config.
+ * @param name Name of the filter to add.
+ */
+const handleAddFilter = (name: string): void => {
+  if (!registry.has(name)) {
+    console.error(
+      chalk.red(
+        `Error: Unknown filter name "${name}". Available filters: ${registry
+          .list()
+          .map((a) => a.name)
+          .join(', ')}`,
+      ),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const active = getActiveFilters();
+  if (active.includes(name)) {
+    console.log(`Filter "${name}" is already active.`);
+    return;
+  }
+
+  active.push(name);
+  setActiveFilters(active);
+  console.log(chalk.green(`Successfully added filter "${name}" to active filters.`));
+};
+
+/**
+ * Removes a filter name from the active filters config.
+ * @param name Name of the filter to remove.
+ */
+const handleRemoveFilter = (name: string): void => {
+  if (!registry.has(name)) {
+    console.error(chalk.red(`Error: Unknown filter name "${name}".`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const active = getActiveFilters();
+
+  if (active.length > 0) {
+    if (!active.includes(name)) {
+      console.log(`Filter "${name}" is not currently active.`);
+      return;
+    }
+    const updated = active.filter((f) => f !== name);
+    setActiveFilters(updated);
+    console.log(chalk.green(`Successfully removed filter "${name}" from active filters.`));
+  } else {
+    if (!DEFAULT_FILTERS.includes(name)) {
+      console.log(`Filter "${name}" is not currently active.`);
+      return;
+    }
+    const updated = DEFAULT_FILTERS.filter((f) => f !== name);
+    setActiveFilters(updated);
+    console.log(chalk.green(`Successfully removed default filter "${name}" from active filters.`));
+  }
+};
+
+/**
+ * Registers the filters subcommands on the Commander program.
+ * @param program Commander program instance.
+ */
+export const registerFiltersCommand = (program: Command): void => {
+  const filters = program
+    .command('filters')
+    .alias('filter')
+    .description('Manage active analyzers filters for kdm analyze');
+
+  filters
+    .command('list')
+    .description('List active and available but inactive filters')
+    .action(handleListFilters);
+
+  filters
+    .command('add <name>')
+    .description('Add a filter to default active filters list')
+    .action(handleAddFilter);
+
+  filters
+    .command('remove <name>')
+    .description('Remove a filter from default active filters list')
+    .action(handleRemoveFilter);
+};

--- a/src/commands/filters.ts
+++ b/src/commands/filters.ts
@@ -16,11 +16,7 @@ const handleListFilters = (): void => {
   const inactiveDisplay = allAvailable.filter((name) => !activeDisplay.includes(name));
 
   console.log(chalk.bold('Active filters:'));
-  if (activeDisplay.length > 0) {
-    activeDisplay.forEach((f) => console.log(`- ${f}`));
-  } else {
-    console.log('(none)');
-  }
+  activeDisplay.forEach((f) => console.log(`- ${f}`));
 
   console.log();
   console.log(chalk.bold('Available but inactive filters:'));
@@ -61,6 +57,32 @@ const handleAddFilter = (name: string): void => {
 };
 
 /**
+ * Removes a filter that was explicitly added to active filters.
+ * @param active Currently configured active filters.
+ * @param name Name of the filter to remove.
+ */
+const removeExplicitFilter = (active: string[], name: string): void => {
+  if (!active.includes(name)) {
+    console.log(`Filter "${name}" is not currently active.`);
+    return;
+  }
+  const updated = active.filter((f) => f !== name);
+  setActiveFilters(updated);
+  console.log(chalk.green(`Successfully removed filter "${name}" from active filters.`));
+};
+
+/**
+ * Removes a default filter when activeFilters configuration is empty.
+ * Initializes configuration with remaining defaults.
+ * @param name Name of the filter to remove.
+ */
+const removeDefaultFilter = (name: string): void => {
+  const updated = DEFAULT_FILTERS.filter((f) => f !== name);
+  setActiveFilters(updated);
+  console.log(chalk.green(`Successfully removed default filter "${name}" from active filters.`));
+};
+
+/**
  * Removes a filter name from the active filters config.
  * @param name Name of the filter to remove.
  */
@@ -72,23 +94,10 @@ const handleRemoveFilter = (name: string): void => {
   }
 
   const active = getActiveFilters();
-
   if (active.length > 0) {
-    if (!active.includes(name)) {
-      console.log(`Filter "${name}" is not currently active.`);
-      return;
-    }
-    const updated = active.filter((f) => f !== name);
-    setActiveFilters(updated);
-    console.log(chalk.green(`Successfully removed filter "${name}" from active filters.`));
+    removeExplicitFilter(active, name);
   } else {
-    if (!DEFAULT_FILTERS.includes(name)) {
-      console.log(`Filter "${name}" is not currently active.`);
-      return;
-    }
-    const updated = DEFAULT_FILTERS.filter((f) => f !== name);
-    setActiveFilters(updated);
-    console.log(chalk.green(`Successfully removed default filter "${name}" from active filters.`));
+    removeDefaultFilter(name);
   }
 };
 

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -9,6 +9,8 @@ import { registerWatchCommand } from './watch';
 import { registerLogsCommand } from './logs';
 import { registerConfigCommand } from './config';
 import { registerAnalyzeCommand } from './analyze';
+import { registerFiltersCommand } from './filters';
+import { registerAuthCommand } from './auth';
 import { logger } from '../utils/logger';
 import { showWelcomeBanner } from '../ui/banner';
 import { createSpinner } from '../ui/spinner';
@@ -26,6 +28,8 @@ registerWatchCommand(program);
 registerLogsCommand(program);
 registerConfigCommand(program);
 registerAnalyzeCommand(program);
+registerFiltersCommand(program);
+registerAuthCommand(program);
 
 const run = async () => {
   if (!process.argv.slice(2).length) {


### PR DESCRIPTION
This PR implements K8sGPT-style filter management (Phase 4) and AI provider management (Phase 5) along with unit tests. Fully compliant with coding_style.md guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `auth` command to manage AI providers: add, update, list, set default, and remove providers
  * Support for multiple AI backends: OpenAI, Anthropic, Ollama, and custom REST endpoints
  * Added `filters` command to manage analyzer filters: list, add, and remove
  * Custom headers and configurable parameters for AI providers

* **Tests**
  * Comprehensive test coverage for auth and filters commands and AI client implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->