### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -67,15 +67,12 @@ const parseCustomHeaders = (headers: string[]): Record<string, string> => {
 };
 
 /**
- * Masks secrets/API keys to avoid leaking them in plain text display.
+ * Returns a non-sensitive credential status for display.
  * @param provider The AI provider configuration.
- * @returns Masked representation.
+ * @returns '(set)' when a password exists, otherwise '(not set)'.
  */
 const getMaskedSecret = (provider: AIProviderConfig): string => {
-  const secret = provider.password;
-  if (!secret) return '(not set)';
-  if (secret.length <= 8) return '********';
-  return `${secret.substring(0, 4)}...${secret.substring(secret.length - 4)}`;
+  return provider.password ? '(set)' : '(not set)';
 };
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/KDM-cli/kdm-cli/security/code-scanning/3](https://github.com/KDM-cli/kdm-cli/security/code-scanning/3)

Best fix: stop emitting any value derived from `provider.password` in logs.  
In `src/commands/auth.ts`, replace the “Password” line to print only presence status, and update masking helper accordingly (or stop using it for output). This preserves functionality (users still know whether credentials are configured) without leaking secret fragments.

Concrete changes:
- In `getMaskedSecret`, return only `'(set)'` or `'(not set)'`, without reading or slicing secret contents beyond existence check.
- Keep line 314 structure intact but now it logs only safe status from `getMaskedSecret(p)`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `auth list` command now displays provider credential status as "(set)" or "(not set)" instead of masked values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->