### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/.github/scripts/tests/test-inactivity-bot.cjs
+++ b/.github/scripts/tests/test-inactivity-bot.cjs
@@ -1071,13 +1071,18 @@ async function runScenario(scenario, index) {
   const capturedLogs = [];
   const originalConsoleLog = console.log;
   const originalConsoleError = console.error;
+  const redactSensitiveText = (text) => text
+    .replace(/((?:password|passwd|token|api[_-]?key|secret)\s*[:=]\s*)([^,\s}]+)/gi, '$1[REDACTED]')
+    .replace(/("(?:password|passwd|token|api[_-]?key|secret)"\s*:\s*")([^"]+)(")/gi, '$1[REDACTED]$3');
+  const sanitizeArgsForOutput = (args) =>
+    args.map(a => redactSensitiveText(String(a))).join(' ');
   console.log = (...args) => {
     capturedLogs.push(args.map(a => String(a)).join(' '));
-    originalConsoleLog(...args);
+    originalConsoleLog(sanitizeArgsForOutput(args));
   };
   console.error = (...args) => {
     capturedLogs.push(args.map(a => String(a)).join(' '));
-    originalConsoleError(...args);
+    originalConsoleError(sanitizeArgsForOutput(args));
   };
 
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/KDM-cli/kdm-cli/security/code-scanning/2](https://github.com/KDM-cli/kdm-cli/security/code-scanning/2)

To fix this safely without changing core behavior, sanitize log arguments before printing them, while still preserving captured logs for test assertions.  
Best approach in `.github/scripts/tests/test-inactivity-bot.cjs`:

1. Add a small local redaction helper in `runScenario` (or nearby) that converts each arg to string and masks common secret patterns (e.g., `password`, `token`, `apiKey`, `secret` in `key=value`, JSON-like, or colon-separated forms).
2. Keep `capturedLogs.push(...)` unchanged so tests continue to observe raw emitted content if needed.
3. Replace `originalConsoleLog(...args)` and `originalConsoleError(...args)` with sanitized output (single joined string), so sensitive material is not printed in clear text to terminal/CI logs.

This requires no new dependencies and only edits to the shown test file region around lines 1071–1081.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
