### PR TITLE
fix: run Dependabot auto-merge from base workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,7 +1,7 @@
 name: Auto-merge Dependabot
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Summary
- Change the Dependabot auto-merge workflow from pull_request to pull_request_target
- Keep the existing Dependabot-only job guard and merge method unchanged

## Why
Existing Dependabot PRs can be based on stale branches that do not contain newly added workflow files, so review events on those PRs do not run the new auto-merge workflow. Running the Dependabot PR lifecycle trigger as pull_request_target evaluates the workflow from the base repository and gives the workflow the repository token permissions needed to enable auto-merge.

## Notes
- This workflow remains guarded to Dependabot PRs only
- Existing stale PRs may need a reopen or synchronize event after this lands to trigger the pull_request_target path

## Validation
- Ran git diff --check