### PR TITLE
fix: harden auto-merge workflows

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -25,4 +25,5 @@ jobs:
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,5 +32,10 @@ jobs:
 
               console.log("PR merged successfully.");
             } catch (error) {
+              if (error.status === 405 && error.message.includes("Required status check")) {
+                core.notice(`PR #${pr.number} is approved but required checks are still pending.`);
+                return;
+              }
+
               core.setFailed(error.message);
             }


### PR DESCRIPTION
## Summary
- Pass the pull request number explicitly to the Dependabot auto-merge action
- Avoid failing the approval auto-merge workflow when required checks are still pending

## Why
The Dependabot auto-merge workflow was running after rebases, but the action invoked an empty PR argument because `pull-request-number` was not set. That made every run fail even though the workflow was triggered correctly.

The approval auto-merge workflow can also fire before required checks complete, which produced red runs for a normal pending-check state.

## Validation
- Verified `pull-request-number` is required in peter-evans/enable-pull-request-automerge action metadata
- Ran `git diff --check`
