### PR TITLE
feat(ci): add unique PR identity

### DIFF
--- a/.github/scripts/helpers/api.cjs
+++ b/.github/scripts/helpers/api.cjs
@@ -134,6 +134,27 @@ async function postComment(botContext, body) {
   }
 }
 
+async function updatePullRequest(botContext, title) {
+  try {
+    requireNonEmptyString(title, 'title');
+
+    await botContext.github.rest.pulls.update({
+      owner: botContext.owner,
+      repo: botContext.repo,
+      pull_number: botContext.number,
+      title,
+    });
+
+    getLogger().log(`Updated PR #${botContext.number} title`);
+    return { success: true };
+  } catch (error) {
+    getLogger().error(
+      `Could not update PR #${botContext.number} title: ${error.message}`,
+    );
+    return { success: false, error: error.message };
+  }
+}
+
 function hasLabel(issueOrPr, labelName) {
   if (!issueOrPr?.labels?.length) return false;
   return issueOrPr.labels.some((label) => {
@@ -467,7 +488,7 @@ async function hasNeedsReviewPR(github, owner, repo, username, issueNumber) {
 }
 
 module.exports = {
-  buildBotContext, addLabels, removeLabel, addAssignees, removeAssignees, postComment, hasLabel, getLabelsByPrefix,
+  buildBotContext, addLabels, removeLabel, addAssignees, removeAssignees, postComment, updatePullRequest, hasLabel, getLabelsByPrefix,
   swapLabels, getBotComment, postOrUpdateComment, fetchPRCommits, fetchOpenPRs, fetchIssue, fetchClosingIssueNumbers,
   fetchLatestMilestone, setMilestone, swapStatusLabel, runAllChecksAndComment, resolveLinkedIssue, acknowledgeComment,
   fetchComments, fetchIssueEvents, closeItem, getHighestIssueSkillLevel, countIssuesByAssignee, listAssignedIssues, hasNeedsReviewPR,

--- a/.github/scripts/pr-labeler.cjs
+++ b/.github/scripts/pr-labeler.cjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-const { buildBotContext, addLabels } = require('./helpers/api.cjs');
+const { buildBotContext, addLabels, updatePullRequest } = require('./helpers/api.cjs');
 const { loadAutomationConfig } = require('./helpers/config-loader.cjs');
 
 function detectType(title) {
@@ -81,6 +81,27 @@ function determineComplexity(score, complexityConfig) {
   return 'complex';
 }
 
+function buildPRIdentityTitle(title, module, typeKey, prNumber) {
+  if (!module || !typeKey || !prNumber) return null;
+
+  const typeMap = {
+    bugFix: 'FIX',
+    feature: 'FEAT',
+    refactor: 'REFACTOR',
+  };
+
+  const type = typeMap[typeKey];
+  if (!type) return null;
+
+  const prefix = `[KDM-${module.toUpperCase()}-${type}-${prNumber}]`;
+
+  const cleanedTitle = title
+  .replace(/^\[KDM-[A-Z0-9-]+-\d+\]\s*/i, '')
+  .trim();
+
+return `${prefix} ${cleanedTitle}`.trim();
+}
+
 async function labelPR({ github, context }) {
   let botContext;
   try {
@@ -159,6 +180,19 @@ async function labelPR({ github, context }) {
     if (label) {
       labelsToAdd.push(label);
       console.log(`[pr-labeler] Complexity: ${key} (score ${score}) → ${label}`);
+    }
+  }
+
+  const prModule = matchedModules[0];
+  const newTitle = buildPRIdentityTitle(title, prModule, typeKey, number);
+
+  if (newTitle && newTitle !== title) {
+    console.log(`[pr-labeler] Updating PR title: "${newTitle}"`);
+
+    const titleResult = await updatePullRequest(botContext, newTitle);
+
+    if (!titleResult.success) {
+      console.log(`[pr-labeler] Failed to update PR title: ${titleResult.error}`);
     }
   }
 

--- a/.github/scripts/pr-labeler.cjs
+++ b/.github/scripts/pr-labeler.cjs
@@ -7,7 +7,7 @@ function detectType(title) {
   if (!title || typeof title !== 'string') return null;
   const upper = title.toUpperCase();
 
-  const kdm = upper.match(/\[KDM-\d+-(FIX|FEAT|REFACTOR)/);
+  const kdm = upper.match(/^\[KDM-[A-Z0-9-]+-(FIX|FEAT|REFACTOR)-\d+\]/);
   if (kdm) {
     const map = { FIX: 'bugFix', FEAT: 'feature', REFACTOR: 'refactor' };
     return map[kdm[1]] || null;
@@ -96,8 +96,8 @@ function buildPRIdentityTitle(title, module, typeKey, prNumber) {
   const prefix = `[KDM-${module.toUpperCase()}-${type}-${prNumber}]`;
 
   const cleanedTitle = title
-  .replace(/^\[KDM-[A-Z0-9-]+-\d+\]\s*/i, '')
-  .trim();
+    .replace(/^\[KDM-(?:[A-Z0-9-]+-(?:FIX|FEAT|REFACTOR)-\d+|\d+-(?:FIX|FEAT|REFACTOR))\]\s*/i, '')
+    .trim();
 
 return `${prefix} ${cleanedTitle}`.trim();
 }


### PR DESCRIPTION
## Summary

- Add unique PR identity generation
- Standardize PR titles as `[KDM-MODULE-TYPE-ID]`
- Update PR titles automatically using the existing labeler workflow
- Reuse the shared `updatePullRequest` API helper

## Changes

- Added `updatePullRequest()` to `.github/scripts/helpers/api.cjs`
- Added unique PR title generation to `.github/scripts/pr-labeler.cjs`
- PR module is detected from changed file paths
- PR type is detected from the title
- PR number is used as the unique identifier

## Validation

- `node --check .github/scripts/helpers/api.cjs` ✅
- `node --check .github/scripts/pr-labeler.cjs` ✅
- `git diff --check` ✅
- `npm test` ✅
- 26 test files passed
- 340 tests passed

Closes #107