### PR TITLE
Interactive TUI for kdm serve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "cosmiconfig": "^9.0.0",
         "dockerode": "^5.0.0",
         "ink": "^7.0.5",
+        "ink-spinner": "^4.0.0",
         "ink-text-input": "^6.0.0",
         "nodemailer": "^9.0.0",
         "react": "^19.2.7"
@@ -963,9 +964,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -983,9 +981,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,9 +998,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1023,9 +1015,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1043,9 +1032,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,9 +1049,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2234,6 +2217,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-table3": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
@@ -3183,6 +3178,22 @@
         }
       }
     },
+    "node_modules/ink-spinner": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-4.0.3.tgz",
+      "integrity": "sha512-uJ4nbH00MM9fjTJ5xdw0zzvtXMkeGb0WV6dzSWvFv2/+ks6FIhpkt+Ge/eLdh0Ah6Vjw5pLMyNfoHQpRDRVFbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ink": ">=3.0.5",
+        "react": ">=16.8.2"
+      }
+    },
     "node_modules/ink-text-input": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
@@ -3589,9 +3600,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3613,9 +3621,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3637,9 +3642,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3661,9 +3663,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dockerode": "^5.0.0",
     "ink": "^7.0.5",
     "ink-text-input": "^6.0.0",
+    "ink-spinner": "^4.0.0",
     "nodemailer": "^9.0.0",
     "react": "^19.2.7"
   },

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { createServer } from '../server/server';
+import { runDashboard } from '../ui/dashboard';
 import { startMCPServer } from '../server/mcp';
 import { logger } from '../utils/logger';
 
@@ -18,21 +19,17 @@ const collectFilter = (value: string, previous: string[]) => [...previous, value
  */
 async function handleHTTPServe(options: any): Promise<void> {
   const port = Number.parseInt(options.port, 10);
-  logger.info(`Starting KDM server on port ${port}...`);
+  logger.info(`Launching interactive dashboard for KDM on port ${port}...`);
 
   try {
-    const server = await createServer({
+    // Launch the interactive Ink dashboard which will manage start/stop/restart
+    await runDashboard({
       port,
       backend: options.backend,
       filter: options.filter?.length ? options.filter : undefined,
-    });
-    logger.success(`KDM server running on http://localhost:${port}`);
-    console.log(chalk.dim('  GET  /health'));
-    console.log(chalk.dim('  POST /analyze'));
-    console.log(chalk.dim('  GET  /filters'));
-    console.log(chalk.dim('  GET  /config'));
+    } as any);
   } catch (error) {
-    logger.error(`Server failed to start: ${(error as Error).message}`);
+    logger.error(`Dashboard failed: ${(error as Error).message}`);
     process.exitCode = 1;
   }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,8 @@ export interface ServerOptions {
   metricsPort?: number;
   backend?: string;
   filter?: string[];
+  // Optional callback invoked on each request for logging/metrics
+  onRequest?: (info: { timestamp: string; method: string; path: string; status: number; responseTimeMs: number }) => void;
 }
 
 /** Simplified request body for the /analyze endpoint. */
@@ -147,8 +149,45 @@ export const routeRequest = (req: any, res: any, options: ServerOptions): void =
  */
 export async function createServer(options: ServerOptions): Promise<{ close: () => void; port: number }> {
   const { createServer: createHttpServer } = await import('node:http');
+  const os = await import('node:os');
 
   const server = createHttpServer((req, res) => {
+    const startMs = Date.now();
+    let recordedStatus = 200;
+
+    // Wrap writeHead to capture status codes set by handlers
+    const origWriteHead = res.writeHead?.bind(res);
+    if (origWriteHead) {
+      // @ts-ignore
+      res.writeHead = function writeHead(statusCode: number, ...rest: any[]) {
+        recordedStatus = statusCode;
+        // @ts-ignore
+        return origWriteHead(statusCode, ...rest);
+      };
+    }
+
+    // Wrap end so we can compute response time once response completes
+    const origEnd = res.end?.bind(res);
+    if (origEnd) {
+      // @ts-ignore
+      res.end = function end(...args: any[]) {
+        const duration = Date.now() - startMs;
+        try {
+          options.onRequest?.({
+            timestamp: new Date(startMs).toISOString(),
+            method: req.method ?? 'GET',
+            path: req.url ?? '/',
+            status: recordedStatus ?? (res.statusCode ?? 200),
+            responseTimeMs: duration,
+          });
+        } catch (e) {
+          // Ignore logging errors
+        }
+        // @ts-ignore
+        return origEnd(...args);
+      };
+    }
+
     routeRequest(req, res, options);
   });
 

--- a/src/ui/dashboard.tsx
+++ b/src/ui/dashboard.tsx
@@ -1,0 +1,186 @@
+import React, {useEffect, useState, useRef} from 'react';
+import {render, Box, Text, useApp, useInput} from 'ink';
+import TextInput from 'ink-text-input';
+import Spinner from 'ink-spinner';
+import chalk from 'chalk';
+import os from 'node:os';
+import {createServer, ServerOptions} from '../server/server';
+
+type LogEntry = {
+  timestamp: string;
+  method: string;
+  path: string;
+  status: number;
+  responseTimeMs: number;
+};
+
+const formatMs = (ms: number) => `${ms}ms`;
+
+const Metrics: React.FC<{uptime: number; cpuPct: number; ramPct: number}> = ({uptime, cpuPct, ramPct}) => (
+  <Box flexDirection="column" paddingRight={2}>
+    <Text>CPU: {cpuPct.toFixed(1)}%</Text>
+    <Text>RAM: {ramPct.toFixed(1)}%</Text>
+    <Text>Uptime: {Math.floor(uptime)}s</Text>
+  </Box>
+);
+
+const RequestRow: React.FC<{entry: LogEntry}> = ({entry}) => (
+  <Box>
+    <Text color="gray">{new Date(entry.timestamp).toLocaleTimeString()} </Text>
+    <Text>{chalk.bold(entry.method)}</Text>
+    <Text> {entry.path} </Text>
+    <Text>{entry.status}</Text>
+    <Text color="gray"> {formatMs(entry.responseTimeMs)}</Text>
+  </Box>
+);
+
+const Dashboard: React.FC<{initialOptions: ServerOptions}> = ({initialOptions}) => {
+  const {exit} = useApp();
+  const [running, setRunning] = useState(false);
+  const [port, setPort] = useState<number>(initialOptions.port ?? 8080);
+  const [editingPort, setEditingPort] = useState(false);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [cpuPct, setCpuPct] = useState(0);
+  const [ramPct, setRamPct] = useState(0);
+  const [uptimeSec, setUptimeSec] = useState(0);
+  const serverRef = useRef<{ close: () => void; port: number } | null>(null);
+
+  const maxLogs = 200;
+
+  const pushLog = (entry: LogEntry) => {
+    setLogs((prev) => {
+      const next = [...prev, entry];
+      if (next.length > maxLogs) next.splice(0, next.length - maxLogs);
+      return next;
+    });
+  };
+
+  const startServer = async () => {
+    try {
+      const srv = await createServer({
+        port,
+        backend: initialOptions.backend,
+        filter: initialOptions.filter,
+        onRequest: (info) => {
+          pushLog(info as LogEntry);
+        },
+      });
+      serverRef.current = srv;
+      setRunning(true);
+    } catch (e) {
+      pushLog({
+        timestamp: new Date().toISOString(),
+        method: 'ERR',
+        path: '/',
+        status: 500,
+        responseTimeMs: 0,
+      });
+    }
+  };
+
+  const stopServer = async () => {
+    try {
+      serverRef.current?.close();
+    } catch (e) {
+      // ignore
+    }
+    serverRef.current = null;
+    setRunning(false);
+  };
+
+  const restartServer = async () => {
+    await stopServer();
+    await startServer();
+  };
+
+  useEffect(() => {
+    // metrics interval
+    const id = setInterval(() => {
+      const total = os.totalmem();
+      const free = os.freemem();
+      const used = total - free;
+      const ram = (used / total) * 100;
+      setRamPct(ram);
+
+      const loads = os.loadavg();
+      const cpus = os.cpus().length || 1;
+      const cpu = (loads[0] / cpus) * 100;
+      setCpuPct(cpu);
+
+      setUptimeSec(process.uptime());
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useInput((input, key) => {
+    if (editingPort) return;
+    if (input === 's') {
+      if (running) stopServer(); else startServer();
+    }
+    if (input === 'r') {
+      restartServer();
+    }
+    if (input === 'c') {
+      setLogs([]);
+    }
+    if (input === 'p') {
+      setEditingPort(true);
+    }
+    if (input === 'Q') {
+      // ensure server closed
+      stopServer();
+      exit();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Box>
+        <Box flexDirection="column" marginRight={4}>
+          <Text bold>kdm Serve Dashboard</Text>
+          <Text>Host: {chalk.green('localhost')}</Text>
+          <Text>Port: {chalk.yellow(String(port))} {running ? <Text color="green">(running)</Text> : <Text color="red">(stopped)</Text>}</Text>
+          <Text>Mode: HTTP</Text>
+        </Box>
+        <Metrics uptime={uptimeSec} cpuPct={cpuPct} ramPct={ramPct} />
+      </Box>
+
+      <Box marginTop={1}>
+        <Box flexDirection="column" width={60}>
+          <Text bold>Controls</Text>
+          <Text> s: start/stop • r: restart • p: change port • c: clear logs • Q: quit</Text>
+        </Box>
+      </Box>
+
+      {editingPort ? (
+        <Box marginTop={1}>
+          <Text>New port: </Text>
+          <TextInput
+            value={String(port)}
+            onChange={(v) => setPort(Number(v) || 0)}
+            onSubmit={async (v) => { setEditingPort(false); if (running) { await restartServer(); } }}
+          />
+        </Box>
+      ) : null}
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>Live Requests (latest)</Text>
+        <Box flexDirection="column" marginTop={1}>
+          {logs.slice(-20).reverse().map((l, i) => (
+            <RequestRow key={`${l.timestamp}-${i}`} entry={l} />
+          ))}
+          {logs.length === 0 && <Text color="gray">No requests yet.</Text>}
+        </Box>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text color="gray">Press Q to quit.</Text>
+      </Box>
+    </Box>
+  );
+};
+
+export function runDashboard(initialOptions: ServerOptions) {
+  const {waitUntilExit} = render(<Dashboard initialOptions={initialOptions} />);
+  return waitUntilExit;
+}


### PR DESCRIPTION
Convert kdm serve to an interactive Ink-based TUI dashboard that shows live request logs, CPU/RAM/uptime metrics, and supports keyboard controls (s start/stop, r restart, p change port, c clear logs, Q quit).\n\nImplements request instrumentation and dashboard UI. Closes #144.