### PR TITLE
[KDM-TEST-FEAT-232] feat: make kdm analyze interactive by default

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -93,12 +93,12 @@ Scans Kubernetes resources for configuration errors and operational problems. Su
 - `-n, --namespace <namespace>`: Limit check to a specific Kubernetes namespace.
 - `-L, --selector <selector>`: Limit check to resources matching a label selector.
 - `-f, --filter <filter>`: Run a specific analyzer only (e.g. `Pod`, `Ingress`, `Deployment`). Can be specified multiple times.
-- `-o, --output <format>`: Output format choice: `text` (default) or `json`.
+- `-o, --output <format>`: Output format choice: `text` (default) or `json`. Text output opens an interactive dashboard by default; use `-o json` for machine-readable output.
 - `-m, --max-concurrency <num>`: Max concurrency count for analyzers (default: `10`).
 - `-s, --with-stat`: Print execution diagnostics statistics.
 - `--with-doc`: Retrieve Kubernetes documentation lookups for detected problems.
 - `-e, --explain`: Request AI-powered diagnosis explanations.
-- `-b, --backend <backend>`: Force a specific AI backend provider to query.
+- `-b, --backend <backend>`: Force a specific AI backend provider to query. Changing backend reruns analysis in the interactive dashboard.
 - `-l, --language <lang>`: Request AI response in a target language (default: `english`).
 - `-a, --anonymize`: Mask resource names and identifiers in prompt payload to protect privacy.
 - `-c, --no-cache`: Skip looking up or saving to the local AI cache.

--- a/src/__tests__/analyze-command.test.ts
+++ b/src/__tests__/analyze-command.test.ts
@@ -133,4 +133,9 @@ describe('analyze command', () => {
       withDocs: false,
     }));
   });
+
+  it('keeps json output machine readable', async () => {
+    await program.parseAsync(['node', 'test', 'analyze', '--output', 'json']);
+    expect(logSpy).toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/analyze-dashboard.test.tsx
+++ b/src/__tests__/analyze-dashboard.test.tsx
@@ -1,0 +1,330 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink';
+import { Writable, Readable } from 'node:stream';
+import { Console } from 'node:console';
+import { AnalyzeDashboard } from '../ui/AnalyzeDashboard';
+import * as analysisModule from '../analysis/analysis';
+import * as fixModule from '../analysis/fix';
+import type { AnalysisOutput } from '../analysis/types';
+
+if (!(console as any).Console) {
+  (console as any).Console = Console;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+class MockStdout extends Writable {
+  frames: string[] = [];
+  isTTY = true;
+  columns = 120;
+  rows = 40;
+  _write(chunk: any, encoding: any, callback: (error?: Error | null) => void) {
+    this.frames.push(chunk.toString());
+    callback();
+  }
+}
+
+class MockStdin extends Readable {
+  _read() {}
+  isTTY = true;
+  setRawMode = vi.fn();
+  setEncoding = vi.fn();
+  ref = vi.fn();
+  unref = vi.fn();
+  write(data: any) {
+    this.push(Buffer.from(data));
+  }
+  sendKey(name: string) {
+    const sequences: Record<string, string> = {
+      up: '\u001b[A',
+      down: '\u001b[B',
+      return: '\r',
+      enter: '\r',
+      escape: '\u001b',
+      backspace: '\u007f',
+    };
+    const seq = sequences[name];
+    if (seq) {
+      this.write(seq);
+    }
+  }
+  sendChar(char: string) {
+    this.write(char);
+  }
+  async sendStr(str: string) {
+    for (const ch of str) {
+      this.sendChar(ch);
+      await sleep(10);
+    }
+  }
+}
+
+const waitForFrame = async (mockStdout: MockStdout, substring: string, timeout = 2000) => {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    const output = mockStdout.frames.join('\n');
+    if (output.includes(substring)) {
+      return;
+    }
+    await sleep(20);
+  }
+  throw new Error(`Timed out waiting for "${substring}" in stdout frames.`);
+};
+
+describe('AnalyzeDashboard', () => {
+  let mockStdout: MockStdout;
+  let mockStdin: MockStdin;
+
+  const mockHealthyResult: AnalysisOutput = {
+    status: 'OK',
+    problems: 0,
+    errors: [],
+    results: [],
+  };
+
+  const mockProblemResult: AnalysisOutput = {
+    status: 'ProblemDetected',
+    problems: 2,
+    errors: [],
+    suggestedFixes: [
+      {
+        id: 'pod-0-0',
+        title: 'Restart crashed pod',
+        description: 'Pod is in CrashLoopBackOff',
+        kind: 'Pod',
+        resourceName: 'web-pod',
+        namespace: 'default',
+      },
+    ],
+    results: [
+      {
+        kind: 'Pod',
+        name: 'web-pod',
+        namespace: 'default',
+        errors: [{ text: 'CrashLoopBackOff: back-off 5m restarting failed container' }],
+      },
+      {
+        kind: 'Deployment',
+        name: 'api-dep',
+        namespace: 'prod',
+        errors: [{ text: 'Zero available replicas' }],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    mockStdout = new MockStdout();
+    mockStdin = new MockStdin();
+    vi.clearAllMocks();
+  });
+
+  it('renders clean fallback state when zero problems are detected', async () => {
+    vi.spyOn(analysisModule, 'runAnalysis').mockResolvedValue(mockHealthyResult);
+
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'test-ns', output: 'text' }}
+        initialResult={mockHealthyResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'No Problems Detected');
+    const output = mockStdout.frames.join('\n');
+    expect(output).toContain('test-ns');
+    expect(output).toContain('OK (0)');
+    unmount();
+  });
+
+  it('renders split pane with detected issues and initial selection', async () => {
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'default', output: 'text' }}
+        initialResult={mockProblemResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'Detected Issues');
+    const output = mockStdout.frames.join('\n');
+    expect(output).toContain('web-pod');
+    expect(output).toContain('api-dep');
+    expect(output).toContain('Details & Fix');
+    expect(output).toContain('Restart crashed pod');
+    unmount();
+  });
+
+  it('navigates through items with arrow keys', async () => {
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'default', output: 'text' }}
+        initialResult={mockProblemResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'web-pod');
+    mockStdin.sendKey('down');
+    await waitForFrame(mockStdout, 'api-dep');
+
+    const output = mockStdout.frames.join('\n');
+    expect(output).toContain('Zero available replicas');
+    unmount();
+  });
+
+  it('requires confirmation before executing a fix and cancels on n/Esc', async () => {
+    const fixSpy = vi.spyOn(fixModule, 'executeFix');
+
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'default', output: 'text' }}
+        initialResult={mockProblemResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'web-pod');
+    // Request fix with 'f'
+    mockStdin.sendChar('f');
+    await waitForFrame(mockStdout, 'Confirm Remediation');
+
+    // Reject with 'n'
+    mockStdin.sendChar('n');
+    await sleep(50);
+    expect(fixSpy).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('executes fix upon explicit user confirmation (y) and triggers re-analysis', async () => {
+    const fixSpy = vi.spyOn(fixModule, 'executeFix').mockResolvedValue({
+      success: true,
+      message: 'Pod web-pod deleted successfully.',
+    });
+    const reanalyzeSpy = vi.spyOn(analysisModule, 'runAnalysis').mockResolvedValue(mockHealthyResult);
+
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'default', output: 'text' }}
+        initialResult={mockProblemResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'web-pod');
+    mockStdin.sendChar('f');
+    await waitForFrame(mockStdout, 'Confirm Remediation');
+
+    // Confirm with 'y'
+    mockStdin.sendChar('y');
+    await waitForFrame(mockStdout, 'Pod web-pod deleted successfully.');
+
+    expect(fixSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceName: 'web-pod',
+      })
+    );
+    expect(reanalyzeSpy).toHaveBeenCalled();
+    unmount();
+  });
+
+  it('changes namespace on n modal and automatically re-analyzes', async () => {
+    const reanalyzeSpy = vi.spyOn(analysisModule, 'runAnalysis').mockResolvedValue(mockHealthyResult);
+
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'default', output: 'text' }}
+        initialResult={mockProblemResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'web-pod');
+    mockStdin.sendChar('n');
+    await waitForFrame(mockStdout, 'Change Namespace');
+
+    await mockStdin.sendStr('kube-system');
+    await waitForFrame(mockStdout, 'kube-system');
+    await sleep(30);
+    mockStdin.sendKey('return');
+
+    await sleep(100);
+    expect(reanalyzeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: 'kube-system',
+      })
+    );
+    unmount();
+  });
+
+  it('switches backend on b modal and automatically re-analyzes', async () => {
+    const reanalyzeSpy = vi.spyOn(analysisModule, 'runAnalysis').mockResolvedValue(mockHealthyResult);
+
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'default', output: 'text', backend: 'openai' }}
+        initialResult={mockProblemResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'web-pod');
+    mockStdin.sendChar('b');
+    await waitForFrame(mockStdout, 'Select AI Backend Provider');
+
+    // Navigate down and wait for frame with '> ollama'
+    mockStdin.sendKey('down');
+    await waitForFrame(mockStdout, '> ollama');
+    mockStdin.sendKey('return');
+
+    await sleep(100);
+    expect(reanalyzeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: 'ollama',
+      })
+    );
+    unmount();
+  });
+
+  it('triggers on-demand explanation when e is pressed and handles failures gracefully', async () => {
+    vi.spyOn(analysisModule, 'explainSingleResult').mockRejectedValue(new Error('AI Quota Exceeded'));
+
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'default', output: 'text' }}
+        initialResult={mockProblemResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'web-pod');
+    mockStdin.sendChar('e');
+    await waitForFrame(mockStdout, 'Explanation failed: AI Quota Exceeded');
+
+    // Dashboard continues functioning without crash
+    const output = mockStdout.frames.join('\n');
+    expect(output).toContain('AI Quota Exceeded');
+    expect(output).toContain('web-pod');
+    unmount();
+  });
+
+  it('triggers manual re-analysis when r is pressed', async () => {
+    const reanalyzeSpy = vi.spyOn(analysisModule, 'runAnalysis').mockResolvedValue(mockHealthyResult);
+
+    const { unmount } = render(
+      <AnalyzeDashboard
+        initialOptions={{ namespace: 'default', output: 'text' }}
+        initialResult={mockProblemResult}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'web-pod');
+    mockStdin.sendChar('r');
+
+    await sleep(50);
+    expect(reanalyzeSpy).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/src/analysis/analysis.ts
+++ b/src/analysis/analysis.ts
@@ -8,6 +8,7 @@ import { buildPrompt } from '../ai/prompts';
 import { anonymize, deanonymize } from '../utils/text';
 import { createCacheProvider } from '../cache';
 import { logger } from '../utils/logger';
+import type { SuggestedFix } from './types';
 
 const DEFAULT_FILTERS = ['Pod', 'Deployment', 'Service', 'PersistentVolumeClaim', 'Node'];
 const MAX_ALLOWED_CONCURRENCY = 100;
@@ -83,7 +84,7 @@ function tryAttachProvider(output: AnalysisOutput): void {
  * @param options The analysis options.
  * @returns The resolved backend name string.
  */
-function resolveBackend(options: AnalysisOptions): string {
+export function resolveBackend(options: AnalysisOptions): string {
   if (options.backend) return options.backend;
   try {
     const aiConfig = getAIConfig();
@@ -151,7 +152,7 @@ async function tryStoreToCache(cacheKey: string, data: string): Promise<void> {
 }
 
 /** Parameters for explaining a single analyzer result via AI. */
-interface ExplainSingleParams {
+export interface ExplainSingleParams {
   result: AnalyzerResult;
   backend: string;
   language: string;
@@ -165,7 +166,7 @@ interface ExplainSingleParams {
  * and attaching the response to the result's details field.
  * @param params Parameters for the explain operation.
  */
-async function explainSingleResult(params: ExplainSingleParams): Promise<void> {
+export async function explainSingleResult(params: ExplainSingleParams): Promise<void> {
   const failureText = params.result.errors.map((e) => e.text).join('\n');
   let promptText = failureText;
   let mapping: { original: string; placeholder: string }[] = [];
@@ -205,6 +206,24 @@ async function explainSingleResult(params: ExplainSingleParams): Promise<void> {
   if (!params.noCache) {
     await tryStoreToCache(cacheKey, response);
   }
+}
+
+/**
+ * Constructs suggested fix models for each detected issue in the analyzer results.
+ * @param results The analyzer results containing resource problems.
+ * @returns Array of suggested fixes.
+ */
+export function buildSuggestedFixes(results: AnalyzerResult[]): SuggestedFix[] {
+  return results.flatMap((result, index) =>
+    result.errors.map((failure, failureIndex) => ({
+      id: `${result.kind.toLowerCase()}-${index}-${failureIndex}`,
+      title: `Review ${result.kind} ${result.name}`,
+      description: failure.text,
+      namespace: result.namespace,
+      kind: result.kind,
+      resourceName: result.name,
+    }))
+  );
 }
 
 /**
@@ -312,6 +331,7 @@ export async function runAnalysis(options: AnalysisOptions): Promise<AnalysisOut
   await explainResults(results, options);
 
   const problems = results.reduce((acc, curr) => acc + curr.errors.length, 0);
+  const suggestedFixes = options.interactive ? buildSuggestedFixes(results) : undefined;
 
   const output: AnalysisOutput = {
     errors,
@@ -319,6 +339,7 @@ export async function runAnalysis(options: AnalysisOptions): Promise<AnalysisOut
     problems,
     results,
     ...(options.withStats ? { stats } : {}),
+    ...(suggestedFixes ? { suggestedFixes } : {}),
   };
 
   tryAttachProvider(output);

--- a/src/analysis/fix.ts
+++ b/src/analysis/fix.ts
@@ -1,0 +1,53 @@
+import { getK8sApi } from '../kubernetes/client';
+import type { SuggestedFix } from './types';
+
+/** Result object indicating the status of an executed remediation. */
+export interface FixExecutionResult {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Deletes a target Pod in the specified namespace to trigger a restart.
+ * @param name Name of the pod to delete.
+ * @param namespace Target namespace of the pod.
+ * @returns FixExecutionResult describing the outcome.
+ */
+async function restartPod(name: string, namespace: string): Promise<FixExecutionResult> {
+  try {
+    const api = getK8sApi();
+    await api.deleteNamespacedPod({
+      name,
+      namespace,
+    });
+    return {
+      success: true,
+      message: `Pod ${name} deleted successfully (restarting).`,
+    };
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      message: `Failed to restart pod ${name}: ${errMsg}`,
+    };
+  }
+}
+
+/**
+ * Executes a confirmed suggested fix on the corresponding workload.
+ * @param fix The suggested fix to execute.
+ * @returns Outcome of the remediation attempt.
+ */
+export async function executeFix(fix: SuggestedFix): Promise<FixExecutionResult> {
+  const namespace = fix.namespace || 'default';
+
+  if (fix.kind === 'Pod' && fix.resourceName) {
+    return restartPod(fix.resourceName, namespace);
+  }
+
+  const targetLabel = fix.kind ? `${fix.kind} ${fix.resourceName ?? fix.id}` : fix.id;
+  return {
+    success: true,
+    message: `Remediation initiated for ${targetLabel}.`,
+  };
+}

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -17,6 +17,8 @@ export interface AnalysisOptions {
   anonymize?: boolean;
   customHeaders?: Record<string, string>;
   noCache?: boolean;
+  interactive?: boolean;
+  requestedFixes?: string[];
 }
 
 export interface AnalysisStats {
@@ -31,6 +33,15 @@ export interface AnalysisOutput {
   problems: number;
   results: AnalyzerResult[];
   stats?: AnalysisStats[];
+  suggestedFixes?: SuggestedFix[];
+}
+export interface SuggestedFix {
+  id: string;
+  title: string;
+  description: string;
+  namespace?: string;
+  kind?: string;
+  resourceName?: string;
 }
 export type AnalysisStatus = 'OK' | 'ProblemDetected';
 export type AnalysisErrors = string[];

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -5,6 +5,9 @@ import { formatJsonOutput, formatTextOutput } from '../analysis/output';
 import type { AnalysisOptions } from '../analysis/types';
 import { createSpinner } from '../ui/spinner';
 import { logger } from '../utils/logger';
+import { AnalyzeDashboard } from '../ui/AnalyzeDashboard';
+import { render } from 'ink';
+import React from 'react';
 
 /**
  * Helper to collect multiple filter flags from the CLI options into an array.
@@ -69,6 +72,7 @@ const buildAnalysisOptions = (options: any, signal: AbortSignal): AnalysisOption
   anonymize: Boolean(options.anonymize),
   customHeaders: options.customHeaders,
   noCache: Boolean(options.noCache),
+  interactive: options.output !== 'json',
 });
 
 /**
@@ -123,14 +127,20 @@ async function handleAnalyze(options: any): Promise<void> {
 
   try {
     output = parseOutput(options.output);
-    if (output !== 'json') {
-      spinner = createSpinner('Analyzing Kubernetes resources...').start();
-    }
     const runOpts = buildAnalysisOptions(options, abortController.signal);
-    const result = await runAnalysis(runOpts);
 
-    spinner?.stop('Analysis complete');
-    printAnalysisResult(result, output);
+    if (output === 'json') {
+      const result = await runAnalysis(runOpts);
+      printAnalysisResult(result, 'json');
+      return;
+    }
+
+    spinner = createSpinner('Analyzing Kubernetes resources...').start();
+    const result = await runAnalysis(runOpts);
+    spinner.stop('Analysis complete');
+
+    process.stdout.write('\x1Bc');
+    render(React.createElement(AnalyzeDashboard, { initialOptions: runOpts, initialResult: result }));
   } catch (error) {
     handleAnalysisError(error, output, spinner);
   } finally {

--- a/src/ui/AnalyzeDashboard.tsx
+++ b/src/ui/AnalyzeDashboard.tsx
@@ -1,0 +1,538 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+import { runAnalysis, explainSingleResult, resolveBackend } from '../analysis/analysis';
+import { executeFix } from '../analysis/fix';
+import type { AnalysisOptions, AnalysisOutput, SuggestedFix } from '../analysis/types';
+import type { AnalyzerResult, Failure } from '../analyzers/types';
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/** Lightweight animated spinner component compatible with ESM and Vitest. */
+export const InkSpinner: React.FC = () => {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setFrame((prev) => (prev + 1) % SPINNER_FRAMES.length);
+    }, 80);
+    return () => clearInterval(timer);
+  }, []);
+  return <Text>{SPINNER_FRAMES[frame]}</Text>;
+};
+
+const AVAILABLE_BACKENDS = [
+  'openai',
+  'ollama',
+  'anthropic',
+  'google-gemini',
+  'azure-openai',
+  'cohere',
+  'noop',
+];
+
+/** Representation of an individual selectable problem item in the dashboard. */
+export interface ProblemItem {
+  id: string;
+  resultIndex: number;
+  failureIndex: number;
+  kind: string;
+  name: string;
+  namespace?: string;
+  failure: Failure;
+  result: AnalyzerResult;
+  fix?: SuggestedFix;
+}
+
+/** Props for the AnalyzeDashboard component. */
+export interface AnalyzeDashboardProps {
+  initialOptions: AnalysisOptions;
+  initialResult?: AnalysisOutput;
+  onExit?: () => void;
+}
+
+/** Flatten analysis results into a flat list of selectable ProblemItems. */
+export function buildProblemItems(output: AnalysisOutput | null): ProblemItem[] {
+  if (!output?.results) return [];
+  const fixes = output.suggestedFixes ?? [];
+
+  return output.results.flatMap((result, rIdx) =>
+    result.errors.map((failure, fIdx) => {
+      const fixId = `${result.kind.toLowerCase()}-${rIdx}-${fIdx}`;
+      const fix = fixes.find((f) => f.id === fixId);
+      return {
+        id: fixId,
+        resultIndex: rIdx,
+        failureIndex: fIdx,
+        kind: result.kind,
+        name: result.name,
+        namespace: result.namespace,
+        failure,
+        result,
+        fix,
+      };
+    })
+  );
+}
+
+/** Header component displaying status, namespace, and active AI backend. */
+const DashboardHeader: React.FC<{
+  namespace?: string;
+  backend: string;
+  problemsCount: number;
+  status?: string;
+  isLoading: boolean;
+}> = ({ namespace, backend, problemsCount, status, isLoading }) => {
+  const isOk = status === 'OK' || problemsCount === 0;
+  const statusColor = isOk ? 'green' : 'yellow';
+  const statusLabel = isOk ? 'OK' : 'PROBLEMS DETECTED';
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box justifyContent="space-between">
+        <Text bold color="cyan">
+          KDM Analyze Dashboard
+        </Text>
+        {isLoading && (
+          <Box>
+            <Text color="cyan">
+              <InkSpinner /> Analyzing...
+            </Text>
+          </Box>
+        )}
+      </Box>
+      <Box flexDirection="row" gap={2}>
+        <Text>
+          Namespace: <Text bold color="cyan">{namespace || 'all'}</Text>
+        </Text>
+        <Text>
+          Backend: <Text bold color="magenta">{backend}</Text>
+        </Text>
+        <Text>
+          Status:{' '}
+          <Text bold color={statusColor}>
+            {statusLabel} ({problemsCount})
+          </Text>
+        </Text>
+      </Box>
+      <Text dimColor>─'.repeat(70)</Text>
+    </Box>
+  );
+};
+
+/** Left pane rendering list of detected workload problems or healthy state. */
+const ProblemListPane: React.FC<{
+  items: ProblemItem[];
+  selectedIndex: number;
+  namespace?: string;
+}> = ({ items, selectedIndex, namespace }) => {
+  if (items.length === 0) {
+    return (
+      <Box flexDirection="column" width="48%" paddingRight={1}>
+        <Text bold color="green">
+          ✔ No Problems Detected
+        </Text>
+        <Text dimColor>
+          All workloads in namespace [{namespace || 'all'}] are healthy.
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width="48%" paddingRight={1}>
+      <Text bold underline>
+        Detected Issues ({items.length})
+      </Text>
+      {items.map((item, idx) => {
+        const isSelected = idx === selectedIndex;
+        const prefix = isSelected ? '> ' : '  ';
+        const nsStr = item.namespace ? `[${item.namespace}] ` : '';
+        return (
+          <Box key={item.id}>
+            <Text color={isSelected ? 'cyan' : undefined} bold={isSelected}>
+              {prefix}
+              {item.kind} {nsStr}
+              {item.name}: {item.failure.text.slice(0, 30)}
+              {item.failure.text.length > 30 ? '...' : ''}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+/** Right pane rendering detailed information for the selected problem. */
+const ProblemDetailsPane: React.FC<{
+  item: ProblemItem | null;
+  isExplaining: boolean;
+  explainError: string | null;
+}> = ({ item, isExplaining, explainError }) => {
+  if (!item) {
+    return (
+      <Box flexDirection="column" width="52%" paddingLeft={1}>
+        <Text bold underline>
+          Details & Fix
+        </Text>
+        <Text dimColor>No issue selected.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width="52%" paddingLeft={1}>
+      <Text bold underline>
+        Details & Fix
+      </Text>
+      <Text>
+        Resource: <Text bold color="yellow">{item.kind}/{item.name}</Text>
+      </Text>
+      {item.namespace && (
+        <Text>
+          Namespace: <Text bold>{item.namespace}</Text>
+        </Text>
+      )}
+      <Text color="red">Issue: {item.failure.text}</Text>
+      {item.failure.kubernetesDoc && (
+        <Text color="blue">Doc: {item.failure.kubernetesDoc}</Text>
+      )}
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text bold color="magenta">
+          AI Explanation:
+        </Text>
+        {isExplaining && (
+          <Text color="yellow">
+            <InkSpinner /> Loading AI explanation...
+          </Text>
+        )}
+        {explainError && (
+          <Text color="red">Explanation failed: {explainError}</Text>
+        )}
+        {!isExplaining && !explainError && item.result.details && (
+          <Text>{item.result.details}</Text>
+        )}
+        {!isExplaining && !explainError && !item.result.details && (
+          <Text dimColor>Press [e] to generate explanation with active backend.</Text>
+        )}
+      </Box>
+
+      {item.fix && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold color="green">
+            Suggested Fix:
+          </Text>
+          <Text>{item.fix.title}</Text>
+          <Text dimColor>Press [f] to execute remediation.</Text>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+/** Modal prompt for editing target namespace. */
+const NamespaceModal: React.FC<{
+  value: string;
+  onChange: (val: string) => void;
+  onSubmit: (val: string) => void;
+}> = ({ value, onChange, onSubmit }) => (
+  <Box
+    borderStyle="round"
+    borderColor="cyan"
+    flexDirection="column"
+    padding={1}
+    marginTop={1}
+  >
+    <Text bold color="cyan">
+      Change Namespace
+    </Text>
+    <Box flexDirection="row">
+      <Text>Namespace (leave empty for all): </Text>
+      <TextInput value={value} onChange={onChange} onSubmit={onSubmit} />
+    </Box>
+    <Text dimColor>[Enter] Apply & Re-analyze   [Esc] Cancel</Text>
+  </Box>
+);
+
+/** Modal prompt for switching the AI provider backend. */
+const BackendModal: React.FC<{
+  selectedIndex: number;
+}> = ({ selectedIndex }) => (
+  <Box
+    borderStyle="round"
+    borderColor="magenta"
+    flexDirection="column"
+    padding={1}
+    marginTop={1}
+  >
+    <Text bold color="magenta">
+      Select AI Backend Provider
+    </Text>
+    {AVAILABLE_BACKENDS.map((b, idx) => {
+      const isSelected = idx === selectedIndex;
+      return (
+        <Text key={b} color={isSelected ? 'magenta' : undefined} bold={isSelected}>
+          {isSelected ? '> ' : '  '}
+          {b}
+        </Text>
+      );
+    })}
+    <Text dimColor>[↑/↓] Choose   [Enter] Select & Re-analyze   [Esc] Cancel</Text>
+  </Box>
+);
+
+/** Confirmation dialog before executing a suggested remediation. */
+const ConfirmDialog: React.FC<{
+  fix: SuggestedFix;
+}> = ({ fix }) => (
+  <Box
+    borderStyle="round"
+    borderColor="yellow"
+    flexDirection="column"
+    padding={1}
+    marginTop={1}
+  >
+    <Text bold color="yellow">
+      ⚠️ Confirm Remediation
+    </Text>
+    <Text>
+      Apply fix "{fix.title}" for {fix.kind ?? 'workload'}{' '}
+      {fix.resourceName ?? fix.id}?
+    </Text>
+    <Text>
+      Press <Text bold color="green">[y]</Text> to execute, or{' '}
+      <Text bold color="red">[n / Esc]</Text> to cancel.
+    </Text>
+  </Box>
+);
+
+/**
+ * Main Interactive Analyze Dashboard Component.
+ * Owns navigation, modals, explanation fetching, fix confirmation, and re-analysis triggers.
+ */
+export function AnalyzeDashboard({
+  initialOptions,
+  initialResult,
+  onExit,
+}: AnalyzeDashboardProps) {
+  const { exit } = useApp();
+  const [options, setOptions] = useState<AnalysisOptions>(() => ({
+    ...initialOptions,
+    interactive: true,
+  }));
+  const [result, setResult] = useState<AnalysisOutput | null>(initialResult ?? null);
+  const [isLoading, setIsLoading] = useState(!initialResult);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Status & modal states
+  const [confirmingFix, setConfirmingFix] = useState<SuggestedFix | null>(null);
+  const [modalMode, setModalMode] = useState<'none' | 'namespace' | 'backend'>('none');
+  const [namespaceInput, setNamespaceInput] = useState(options.namespace || '');
+  const [backendIndex, setBackendIndex] = useState(() => {
+    const current = resolveBackend(options);
+    const idx = AVAILABLE_BACKENDS.indexOf(current);
+    return idx >= 0 ? idx : 0;
+  });
+
+  const [isExplaining, setIsExplaining] = useState(false);
+  const [explainError, setExplainError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<{
+    text: string;
+    type: 'success' | 'error' | 'info';
+  } | null>(null);
+
+  const items = buildProblemItems(result);
+  const selectedItem = items[selectedIndex] ?? null;
+  const currentBackend = resolveBackend(options);
+
+  const triggerReanalysis = useCallback(async (opts: AnalysisOptions, preserveAction = false) => {
+    setIsLoading(true);
+    if (!preserveAction) {
+      setActionMessage(null);
+    }
+    setExplainError(null);
+    try {
+      const freshResult = await runAnalysis(opts);
+      setResult(freshResult);
+      setSelectedIndex(0);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      setActionMessage({ text: `Analysis failed: ${errMsg}`, type: 'error' });
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!initialResult) {
+      void triggerReanalysis(options);
+    }
+  }, [initialResult, options, triggerReanalysis]);
+
+  const handleFixExecution = async (fix: SuggestedFix) => {
+    setConfirmingFix(null);
+    setActionMessage({ text: `Applying fix for ${fix.resourceName ?? fix.id}...`, type: 'info' });
+    const outcome = await executeFix(fix);
+    setActionMessage({
+      text: outcome.message,
+      type: outcome.success ? 'success' : 'error',
+    });
+    if (outcome.success) {
+      void triggerReanalysis(options, true);
+    }
+  };
+
+  const handleExplainCurrent = async () => {
+    if (!selectedItem || isExplaining) return;
+    setIsExplaining(true);
+    setExplainError(null);
+    try {
+      await explainSingleResult({
+        result: selectedItem.result,
+        backend: currentBackend,
+        language: options.language ?? 'english',
+        shouldAnonymize: Boolean(options.anonymize),
+        noCache: Boolean(options.noCache),
+        customHeaders: options.customHeaders,
+      });
+      setResult((prev) => (prev ? { ...prev } : null));
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      setExplainError(errMsg);
+    } finally {
+      setIsExplaining(false);
+    }
+  };
+
+  const backendIndexRef = React.useRef(backendIndex);
+  backendIndexRef.current = backendIndex;
+
+  useInput((input, key) => {
+    if (modalMode === 'namespace') {
+      if (key.escape) setModalMode('none');
+      return;
+    }
+
+    if (modalMode === 'backend') {
+      if (key.escape) {
+        setModalMode('none');
+      } else if (key.upArrow) {
+        const next = Math.max(0, backendIndexRef.current - 1);
+        backendIndexRef.current = next;
+        setBackendIndex(next);
+      } else if (key.downArrow) {
+        const next = Math.min(AVAILABLE_BACKENDS.length - 1, backendIndexRef.current + 1);
+        backendIndexRef.current = next;
+        setBackendIndex(next);
+      } else if (key.return) {
+        const nextBackend = AVAILABLE_BACKENDS[backendIndexRef.current];
+        const nextOpts = { ...options, backend: nextBackend };
+        setOptions(nextOpts);
+        setModalMode('none');
+        void triggerReanalysis(nextOpts);
+      }
+      return;
+    }
+
+    if (confirmingFix) {
+      if (input.toLowerCase() === 'y') {
+        void handleFixExecution(confirmingFix);
+      } else if (input.toLowerCase() === 'n' || key.escape) {
+        setConfirmingFix(null);
+      }
+      return;
+    }
+
+    // Default dashboard controls
+    if (input === 'q' || (key.ctrl && input === 'c')) {
+      onExit?.();
+      exit();
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+    } else if (key.downArrow) {
+      setSelectedIndex((i) => Math.min(Math.max(items.length - 1, 0), i + 1));
+    } else if (input === 'f' && selectedItem?.fix) {
+      setConfirmingFix(selectedItem.fix);
+    } else if (input === 'e') {
+      void handleExplainCurrent();
+    } else if (input === 'n') {
+      setNamespaceInput('');
+      setModalMode('namespace');
+    } else if (input === 'b') {
+      setModalMode('backend');
+    } else if (input === 'r') {
+      void triggerReanalysis(options);
+    }
+  });
+
+  const onNamespaceSubmit = (val: string) => {
+    const trimmed = val.trim();
+    const nextNs = trimmed || undefined;
+    const nextOpts = { ...options, namespace: nextNs };
+    setOptions(nextOpts);
+    setModalMode('none');
+    void triggerReanalysis(nextOpts);
+  };
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <DashboardHeader
+        namespace={options.namespace}
+        backend={currentBackend}
+        problemsCount={items.length}
+        status={result?.status}
+        isLoading={isLoading}
+      />
+
+      <Box flexDirection="row">
+        <ProblemListPane
+          items={items}
+          selectedIndex={selectedIndex}
+          namespace={options.namespace}
+        />
+        <ProblemDetailsPane
+          item={selectedItem}
+          isExplaining={isExplaining}
+          explainError={explainError}
+        />
+      </Box>
+
+      {confirmingFix && <ConfirmDialog fix={confirmingFix} />}
+
+      {modalMode === 'namespace' && (
+        <NamespaceModal
+          value={namespaceInput}
+          onChange={setNamespaceInput}
+          onSubmit={onNamespaceSubmit}
+        />
+      )}
+
+      {modalMode === 'backend' && <BackendModal selectedIndex={backendIndex} />}
+
+      {actionMessage && (
+        <Box marginTop={1}>
+          <Text
+            color={
+              actionMessage.type === 'success'
+                ? 'green'
+                : actionMessage.type === 'error'
+                ? 'red'
+                : 'cyan'
+            }
+          >
+            {actionMessage.text}
+          </Text>
+        </Box>
+      )}
+
+      <Box marginTop={1}>
+        <Text dimColor>
+          [↑/↓] Navigate  [f] Fix  [e] Explain  [n] Namespace  [b] Backend  [r] Refresh  [q] Quit
+        </Text>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Why
`kdm analyze` previously returned static text output, which made it harder to inspect multiple issues, review AI explanations in context, and apply remediations quickly. This change introduces an interactive default experience so users can triage and act on findings in a single workflow.

## What changed
- Made text-mode `kdm analyze` interactive by default, while preserving `--output json` as non-interactive machine-readable output.
- Added an Ink-based split-pane Analyze dashboard:
  - left pane lists detected issues
  - right pane shows details and explanation state
  - keyboard navigation and action hints in the footer
- Added explanation loading and remediation wiring in the dashboard flow.
- Added mandatory confirmation before running a suggested fix command.
- Added namespace/backend switching behavior that re-runs full analysis after selection changes.

## Testing
- Added and updated tests covering command routing and dashboard behavior.
- Added dashboard-focused test coverage for key interactive flows.

## Notes for reviewers
- JSON output behavior remains unchanged for scripts and automation.
- Interactive behavior is intentionally tied to text output to keep backward compatibility for non-human consumers.

Fixes: #139