### PR TITLE
[KDM-TEST-FEAT-233] feat(root): interactive InitialDashboard for root kdm command

### DIFF
--- a/src/__tests__/initial-dashboard.test.tsx
+++ b/src/__tests__/initial-dashboard.test.tsx
@@ -222,4 +222,48 @@ describe('InitialDashboard', () => {
     expect(exitSpy).toHaveBeenCalled();
     unmount();
   });
+
+  it('navigates to help screen and returns back to main dashboard on Esc or B', async () => {
+    const { unmount } = render(
+      <InitialDashboard
+        version="2.0.1"
+        initialDocker={mockDockerConnected}
+        initialK8s={mockK8sConnected}
+        initialMinikube={mockMinikubeRunning}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
+    mockStdin.sendChar('?');
+    await waitForFrame(mockStdout, 'KDM - Kubernetes & Docker Monitoring CLI Help');
+
+    // Press 'b' to go back
+    mockStdin.sendChar('b');
+    await waitForFrame(mockStdout, 'Select an Action to Launch:');
+
+    unmount();
+  });
+
+  it('navigates to analyze subscreen and returns back to home dashboard on Esc', async () => {
+    const { unmount } = render(
+      <InitialDashboard
+        version="2.0.1"
+        initialDocker={mockDockerConnected}
+        initialK8s={mockK8sConnected}
+        initialMinikube={mockMinikubeRunning}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
+    mockStdin.sendChar('a');
+    await waitForFrame(mockStdout, 'KDM Analyze Dashboard');
+
+    // Press Escape to go back
+    mockStdin.sendKey('escape');
+    await waitForFrame(mockStdout, 'Select an Action to Launch:');
+
+    unmount();
+  });
 });

--- a/src/__tests__/initial-dashboard.test.tsx
+++ b/src/__tests__/initial-dashboard.test.tsx
@@ -79,16 +79,21 @@ describe('InitialDashboard', () => {
     vi.clearAllMocks();
   });
 
-  it('renders banner, version, connection status, and command list', async () => {
-    const { unmount } = render(
+  const renderDashboard = (props: Partial<React.ComponentProps<typeof InitialDashboard>> = {}) => {
+    return render(
       <InitialDashboard
         version="2.0.1"
         initialDocker={mockDockerConnected}
         initialK8s={mockK8sConnected}
         initialMinikube={mockMinikubeRunning}
+        {...props}
       />,
       { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
     );
+  };
+
+  it('renders banner, version, connection status, and command list', async () => {
+    const { unmount } = renderDashboard();
 
     await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor v2.0.1');
     const output = mockStdout.frames.join('\n');
@@ -104,15 +109,7 @@ describe('InitialDashboard', () => {
   });
 
   it('navigates through menu items with arrow keys and updates preview', async () => {
-    const { unmount } = render(
-      <InitialDashboard
-        version="2.0.1"
-        initialDocker={mockDockerConnected}
-        initialK8s={mockK8sConnected}
-        initialMinikube={mockMinikubeRunning}
-      />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
-    );
+    const { unmount } = renderDashboard();
 
     await waitForFrame(mockStdout, '> 🔍 Analyze Cluster');
     mockStdin.sendKey('down');
@@ -126,16 +123,7 @@ describe('InitialDashboard', () => {
   it('launches selected action on Enter', async () => {
     const selectSpy = vi.fn();
 
-    const { unmount } = render(
-      <InitialDashboard
-        version="2.0.1"
-        onSelect={selectSpy}
-        initialDocker={mockDockerConnected}
-        initialK8s={mockK8sConnected}
-        initialMinikube={mockMinikubeRunning}
-      />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
-    );
+    const { unmount } = renderDashboard({ onSelect: selectSpy });
 
     await waitForFrame(mockStdout, '> 🔍 Analyze Cluster');
     mockStdin.sendKey('return');
@@ -148,16 +136,7 @@ describe('InitialDashboard', () => {
   it('launches action directly via shortcut hotkey', async () => {
     const selectSpy = vi.fn();
 
-    const { unmount } = render(
-      <InitialDashboard
-        version="2.0.1"
-        onSelect={selectSpy}
-        initialDocker={mockDockerConnected}
-        initialK8s={mockK8sConnected}
-        initialMinikube={mockMinikubeRunning}
-      />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
-    );
+    const { unmount } = renderDashboard({ onSelect: selectSpy });
 
     await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
     mockStdin.sendChar('w');
@@ -181,15 +160,7 @@ describe('InitialDashboard', () => {
       running: true,
     });
 
-    const { unmount } = render(
-      <InitialDashboard
-        version="2.0.1"
-        initialDocker={mockDockerConnected}
-        initialK8s={mockK8sConnected}
-        initialMinikube={mockMinikubeRunning}
-      />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
-    );
+    const { unmount } = renderDashboard();
 
     await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
     mockStdin.sendChar('r');
@@ -204,35 +175,24 @@ describe('InitialDashboard', () => {
   it('triggers onExit when q or escape is pressed', async () => {
     const exitSpy = vi.fn();
 
-    const { unmount } = render(
-      <InitialDashboard
-        version="2.0.1"
-        onExit={exitSpy}
-        initialDocker={mockDockerConnected}
-        initialK8s={mockK8sConnected}
-        initialMinikube={mockMinikubeRunning}
-      />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
-    );
+    const { unmount } = renderDashboard({ onExit: exitSpy });
 
     await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
     mockStdin.sendChar('q');
     await sleep(50);
 
-    expect(exitSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+
+    exitSpy.mockClear();
+    mockStdin.sendKey('escape');
+    await sleep(50);
+
+    expect(exitSpy).toHaveBeenCalledTimes(1);
     unmount();
   });
 
   it('navigates to help screen and returns back to main dashboard on Esc or B', async () => {
-    const { unmount } = render(
-      <InitialDashboard
-        version="2.0.1"
-        initialDocker={mockDockerConnected}
-        initialK8s={mockK8sConnected}
-        initialMinikube={mockMinikubeRunning}
-      />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
-    );
+    const { unmount } = renderDashboard();
 
     await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
     mockStdin.sendChar('?');
@@ -246,15 +206,7 @@ describe('InitialDashboard', () => {
   });
 
   it('navigates to analyze subscreen and returns back to home dashboard on Esc', async () => {
-    const { unmount } = render(
-      <InitialDashboard
-        version="2.0.1"
-        initialDocker={mockDockerConnected}
-        initialK8s={mockK8sConnected}
-        initialMinikube={mockMinikubeRunning}
-      />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
-    );
+    const { unmount } = renderDashboard();
 
     await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
     mockStdin.sendChar('a');

--- a/src/__tests__/initial-dashboard.test.tsx
+++ b/src/__tests__/initial-dashboard.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink';
+import { Writable, Readable } from 'node:stream';
+import { Console } from 'node:console';
+import { InitialDashboard } from '../ui/InitialDashboard';
+import * as dockerClient from '../docker/client';
+import * as k8sClient from '../kubernetes/client';
+import * as minikubeClient from '../minikube/client';
+
+if (!(console as any).Console) {
+  (console as any).Console = Console;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+class MockStdout extends Writable {
+  frames: string[] = [];
+  isTTY = true;
+  columns = 120;
+  rows = 40;
+  _write(chunk: any, encoding: any, callback: (error?: Error | null) => void) {
+    this.frames.push(chunk.toString());
+    callback();
+  }
+}
+
+class MockStdin extends Readable {
+  _read() {}
+  isTTY = true;
+  setRawMode = vi.fn();
+  setEncoding = vi.fn();
+  ref = vi.fn();
+  unref = vi.fn();
+  write(data: any) {
+    this.push(Buffer.from(data));
+  }
+  sendKey(name: string) {
+    const sequences: Record<string, string> = {
+      up: '\u001b[A',
+      down: '\u001b[B',
+      return: '\r',
+      enter: '\r',
+      escape: '\u001b',
+    };
+    const seq = sequences[name];
+    if (seq) {
+      this.write(seq);
+    }
+  }
+  sendChar(char: string) {
+    this.write(char);
+  }
+}
+
+const waitForFrame = async (mockStdout: MockStdout, substring: string, timeout = 2000) => {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    const output = mockStdout.frames.join('\n');
+    if (output.includes(substring)) {
+      return;
+    }
+    await sleep(20);
+  }
+  throw new Error(`Timed out waiting for "${substring}" in stdout frames.`);
+};
+
+describe('InitialDashboard', () => {
+  let mockStdout: MockStdout;
+  let mockStdin: MockStdin;
+
+  const mockDockerConnected = { connected: true, containerCount: 5 };
+  const mockK8sConnected = { connected: true, podCount: 12 };
+  const mockMinikubeRunning = { installed: true, running: true };
+
+  beforeEach(() => {
+    mockStdout = new MockStdout();
+    mockStdin = new MockStdin();
+    vi.clearAllMocks();
+  });
+
+  it('renders banner, version, connection status, and command list', async () => {
+    const { unmount } = render(
+      <InitialDashboard
+        version="2.0.1"
+        initialDocker={mockDockerConnected}
+        initialK8s={mockK8sConnected}
+        initialMinikube={mockMinikubeRunning}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor v2.0.1');
+    const output = mockStdout.frames.join('\n');
+    expect(output).toContain('Docker:');
+    expect(output).toContain('5 containers');
+    expect(output).toContain('Kubernetes:');
+    expect(output).toContain('12 pods');
+    expect(output).toContain('Minikube:');
+    expect(output).toContain('RUNNING');
+    expect(output).toContain('Analyze Cluster');
+    expect(output).toContain('Show Resources');
+    unmount();
+  });
+
+  it('navigates through menu items with arrow keys and updates preview', async () => {
+    const { unmount } = render(
+      <InitialDashboard
+        version="2.0.1"
+        initialDocker={mockDockerConnected}
+        initialK8s={mockK8sConnected}
+        initialMinikube={mockMinikubeRunning}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, '> 🔍 Analyze Cluster');
+    mockStdin.sendKey('down');
+    await waitForFrame(mockStdout, '> 📊 Show Resources');
+
+    const output = mockStdout.frames.join('\n');
+    expect(output).toContain('Command: kdm show runners');
+    unmount();
+  });
+
+  it('launches selected action on Enter', async () => {
+    const selectSpy = vi.fn();
+
+    const { unmount } = render(
+      <InitialDashboard
+        version="2.0.1"
+        onSelect={selectSpy}
+        initialDocker={mockDockerConnected}
+        initialK8s={mockK8sConnected}
+        initialMinikube={mockMinikubeRunning}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, '> 🔍 Analyze Cluster');
+    mockStdin.sendKey('return');
+    await sleep(50);
+
+    expect(selectSpy).toHaveBeenCalledWith(['analyze']);
+    unmount();
+  });
+
+  it('launches action directly via shortcut hotkey', async () => {
+    const selectSpy = vi.fn();
+
+    const { unmount } = render(
+      <InitialDashboard
+        version="2.0.1"
+        onSelect={selectSpy}
+        initialDocker={mockDockerConnected}
+        initialK8s={mockK8sConnected}
+        initialMinikube={mockMinikubeRunning}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
+    mockStdin.sendChar('w');
+    await sleep(50);
+
+    expect(selectSpy).toHaveBeenCalledWith(['watch']);
+    unmount();
+  });
+
+  it('refreshes connections when r is pressed', async () => {
+    const dockerSpy = vi.spyOn(dockerClient, 'checkDockerConnection').mockResolvedValue({
+      connected: true,
+      containerCount: 8,
+    });
+    const k8sSpy = vi.spyOn(k8sClient, 'checkK8sConnection').mockResolvedValue({
+      connected: true,
+      podCount: 15,
+    });
+    const minikubeSpy = vi.spyOn(minikubeClient, 'checkMinikubeConnection').mockResolvedValue({
+      installed: true,
+      running: true,
+    });
+
+    const { unmount } = render(
+      <InitialDashboard
+        version="2.0.1"
+        initialDocker={mockDockerConnected}
+        initialK8s={mockK8sConnected}
+        initialMinikube={mockMinikubeRunning}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
+    mockStdin.sendChar('r');
+
+    await sleep(50);
+    expect(dockerSpy).toHaveBeenCalled();
+    expect(k8sSpy).toHaveBeenCalled();
+    expect(minikubeSpy).toHaveBeenCalled();
+    unmount();
+  });
+
+  it('triggers onExit when q or escape is pressed', async () => {
+    const exitSpy = vi.fn();
+
+    const { unmount } = render(
+      <InitialDashboard
+        version="2.0.1"
+        onExit={exitSpy}
+        initialDocker={mockDockerConnected}
+        initialK8s={mockK8sConnected}
+        initialMinikube={mockMinikubeRunning}
+      />,
+      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+    );
+
+    await waitForFrame(mockStdout, 'Kubernetes & Docker Monitor');
+    mockStdin.sendChar('q');
+    await sleep(50);
+
+    expect(exitSpy).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/src/__tests__/navigation-utils.test.ts
+++ b/src/__tests__/navigation-utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { triggerBack, triggerExit } from '../ui/navigation-utils';
+
+describe('navigation-utils', () => {
+  let originalExit: typeof process.exit;
+
+  beforeEach(() => {
+    originalExit = process.exit;
+    process.exit = vi.fn() as any;
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    vi.clearAllMocks();
+  });
+
+  describe('triggerBack', () => {
+    it('calls onBack when provided and does not exit', () => {
+      const onBackSpy = vi.fn();
+      const exitFnSpy = vi.fn();
+
+      triggerBack(onBackSpy, exitFnSpy);
+
+      expect(onBackSpy).toHaveBeenCalledTimes(1);
+      expect(exitFnSpy).not.toHaveBeenCalled();
+      expect(process.exit).not.toHaveBeenCalled();
+    });
+
+    it('calls exitFn and process.exit(0) when onBack is not provided', () => {
+      const exitFnSpy = vi.fn();
+
+      triggerBack(undefined, exitFnSpy);
+
+      expect(exitFnSpy).toHaveBeenCalledTimes(1);
+      expect(process.exit).toHaveBeenCalledWith(0);
+    });
+
+    it('handles undefined exitFn gracefully', () => {
+      triggerBack(undefined, undefined);
+
+      expect(process.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('triggerExit', () => {
+    it('calls onExit when provided and does not exit process', () => {
+      const onExitSpy = vi.fn();
+      const exitFnSpy = vi.fn();
+
+      triggerExit(onExitSpy, exitFnSpy);
+
+      expect(onExitSpy).toHaveBeenCalledTimes(1);
+      expect(exitFnSpy).not.toHaveBeenCalled();
+      expect(process.exit).not.toHaveBeenCalled();
+    });
+
+    it('calls exitFn and process.exit(0) when onExit is not provided', () => {
+      const exitFnSpy = vi.fn();
+
+      triggerExit(undefined, exitFnSpy);
+
+      expect(exitFnSpy).toHaveBeenCalledTimes(1);
+      expect(process.exit).toHaveBeenCalledWith(0);
+    });
+
+    it('handles undefined exitFn gracefully', () => {
+      triggerExit(undefined, undefined);
+
+      expect(process.exit).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -43,54 +43,111 @@ registerCustomAnalyzerCommand(program);
 // Register integration analyzers
 registerIntegrations();
 
+import React from 'react';
+import { render } from 'ink';
+import { InitialDashboard } from '../ui/InitialDashboard';
+
+/**
+ * Renders connection status badges and resource metrics in non-interactive mode.
+ * @param dockerStatus Result from checkDockerConnection.
+ * @param k8sStatus Result from checkK8sConnection.
+ * @param minikubeStatus Result from checkMinikubeConnection.
+ */
+function printStatusBadges(
+  dockerStatus: { connected: boolean; containerCount: number },
+  k8sStatus: { connected: boolean; podCount: number },
+  minikubeStatus: { installed: boolean; running: boolean }
+): void {
+  const badge = (text: string, color: 'green' | 'red' | 'yellow') => {
+    const styles = {
+      green: chalk.bgGreen.black.bold,
+      red: chalk.bgRed.white.bold,
+      yellow: chalk.bgYellow.black.bold,
+    };
+    return styles[color](` ${text} `);
+  };
+
+  const dockerStr = dockerStatus.connected ? badge('CONNECTED', 'green') : badge('DISCONNECTED', 'red');
+  const k8sStr = k8sStatus.connected ? badge('CONNECTED', 'green') : badge('DISCONNECTED', 'red');
+
+  let minikubeStr = badge('NOT INSTALLED', 'red');
+  if (minikubeStatus.installed) {
+    minikubeStr = minikubeStatus.running ? badge('RUNNING', 'green') : badge('STOPPED', 'yellow');
+  }
+
+  console.log(`${chalk.bold('Docker:')}      ${dockerStr}`);
+  console.log(`${chalk.bold('Kubernetes:')}  ${k8sStr}`);
+  console.log(`${chalk.bold('Minikube:')}    ${minikubeStr}\n`);
+
+  console.log(`${chalk.cyan('󰡨')} Running Containers: ${chalk.yellow.bold(dockerStatus.containerCount)}`);
+  console.log(`${chalk.blue('󱔎')} Running Pods:       ${chalk.yellow.bold(k8sStatus.podCount)}`);
+  console.log(`${chalk.red('󰒑')} Unhealthy Services: ${chalk.yellow.bold('0')} (Mocked)\n`);
+  console.log(chalk.bold('Commands:\n'));
+  console.log(`  kdm show runners\n  kdm health all\n  kdm watch\n  kdm logs <name>\n`);
+}
+
+/**
+ * Runs the fallback non-interactive connection check and prints output.
+ */
+async function runNonInteractiveSummary(): Promise<void> {
+  showWelcomeBanner(VERSION);
+  const spinner = createSpinner('Checking connections...').start();
+  let hadError = false;
+  try {
+    const [dockerStatus, k8sStatus, minikubeStatus] = await Promise.all([
+      checkDockerConnection(),
+      checkK8sConnection(),
+      checkMinikubeConnection(),
+    ]);
+    spinner.stop('Connection check complete');
+    console.log();
+    printStatusBadges(dockerStatus, k8sStatus, minikubeStatus);
+  } catch (error) {
+    hadError = true;
+    spinner.fail(`Connection check failed: ${(error as Error).message}`);
+  } finally {
+    program.outputHelp();
+    process.exit(hadError ? 1 : 0);
+  }
+}
+
+/**
+ * Launches the interactive InitialDashboard TUI.
+ */
+async function launchInteractiveDashboard(): Promise<void> {
+  process.stdout.write('\x1Bc');
+  const instance = render(
+    React.createElement(InitialDashboard, {
+      version: VERSION,
+      onSelect: async (cmdArgs: string[]) => {
+        instance.unmount();
+        process.stdout.write('\x1Bc');
+        if (cmdArgs.length === 0) {
+          process.exit(0);
+        } else if (cmdArgs.includes('--help')) {
+          program.outputHelp();
+          process.exit(0);
+        } else {
+          await program.parseAsync(['node', 'kdm', ...cmdArgs]);
+        }
+      },
+      onExit: () => {
+        instance.unmount();
+        process.exit(0);
+      },
+    })
+  );
+  await instance.waitUntilExit();
+}
+
 const run = async () => {
   if (!process.argv.slice(2).length) {
-    showWelcomeBanner(VERSION);
-
-    const spinner = createSpinner('Checking connections...').start();
-    let hadError = false;
-    try {
-      const [dockerStatus, k8sStatus, minikubeStatus] = await Promise.all([
-        checkDockerConnection(),
-        checkK8sConnection(),
-        checkMinikubeConnection()
-      ]);
-      spinner.stop('Connection check complete');
-      console.log();
-
-      const badge = (text: string, color: 'green' | 'red' | 'yellow') => {
-        const styles = {
-          green: chalk.bgGreen.black.bold,
-          red: chalk.bgRed.white.bold,
-          yellow: chalk.bgYellow.black.bold,
-        };
-        return styles[color](` ${text} `);
-      };
-
-      const dockerStr = dockerStatus.connected ? badge('CONNECTED', 'green') : badge('DISCONNECTED', 'red');
-      const k8sStr = k8sStatus.connected ? badge('CONNECTED', 'green') : badge('DISCONNECTED', 'red');
-      
-      let minikubeStr = badge('NOT INSTALLED', 'red');
-      if (minikubeStatus.installed) {
-        minikubeStr = minikubeStatus.running ? badge('RUNNING', 'green') : badge('STOPPED', 'yellow');
-      }
-
-      console.log(`${chalk.bold('Docker:')}      ${dockerStr}`);
-      console.log(`${chalk.bold('Kubernetes:')}  ${k8sStr}`);
-      console.log(`${chalk.bold('Minikube:')}    ${minikubeStr}\n`);
-      
-      console.log(`${chalk.cyan('󰡨')} Running Containers: ${chalk.yellow.bold(dockerStatus.containerCount)}`);
-      console.log(`${chalk.blue('󱔎')} Running Pods:       ${chalk.yellow.bold(k8sStatus.podCount)}`);
-      console.log(`${chalk.red('󰒑')} Unhealthy Services: ${chalk.yellow.bold('0')} (Mocked)\n`);
-      console.log(chalk.bold('Commands:\n'));
-      console.log(`  kdm show runners\n  kdm health all\n  kdm watch\n  kdm logs <name>\n`);
-    } catch (error) {
-      hadError = true;
-      spinner.fail(`Connection check failed: ${(error as Error).message}`);
-    } finally {
-      program.outputHelp();
-      process.exit(hadError ? 1 : 0);
+    if (process.stdout.isTTY && process.stdin.isTTY) {
+      await launchInteractiveDashboard();
+      return;
     }
+    await runNonInteractiveSummary();
+    return;
   }
 
   program.parse(process.argv);
@@ -100,3 +157,4 @@ const run = async () => {
 };
 
 run();
+

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -122,13 +122,18 @@ async function launchInteractiveDashboard(): Promise<void> {
       onSelect: async (cmdArgs: string[]) => {
         instance.unmount();
         process.stdout.write('\x1Bc');
-        if (cmdArgs.length === 0) {
-          process.exit(0);
-        } else if (cmdArgs.includes('--help')) {
-          program.outputHelp();
-          process.exit(0);
-        } else {
-          await program.parseAsync(['node', 'kdm', ...cmdArgs]);
+        try {
+          if (cmdArgs.length === 0) {
+            process.exit(0);
+          } else if (cmdArgs.includes('--help')) {
+            program.outputHelp();
+            process.exit(0);
+          } else {
+            await program.parseAsync(['node', 'kdm', ...cmdArgs]);
+          }
+        } catch (error) {
+          console.error(chalk.red(`Command failed: ${(error as Error).message}`));
+          process.exit(1);
         }
       },
       onExit: () => {

--- a/src/ui/AnalyzeDashboard.tsx
+++ b/src/ui/AnalyzeDashboard.tsx
@@ -48,6 +48,7 @@ export interface AnalyzeDashboardProps {
   initialOptions: AnalysisOptions;
   initialResult?: AnalysisOutput;
   onExit?: () => void;
+  onBack?: () => void;
 }
 
 /** Flatten analysis results into a flat list of selectable ProblemItems. */
@@ -250,7 +251,7 @@ const NamespaceModal: React.FC<{
       <Text>Namespace (leave empty for all): </Text>
       <TextInput value={value} onChange={onChange} onSubmit={onSubmit} />
     </Box>
-    <Text dimColor>[Enter] Apply & Re-analyze   [Esc] Cancel</Text>
+    <Text dimColor>[Enter] Apply & Re-analyze   [Esc] Back</Text>
   </Box>
 );
 
@@ -271,13 +272,13 @@ const BackendModal: React.FC<{
     {AVAILABLE_BACKENDS.map((b, idx) => {
       const isSelected = idx === selectedIndex;
       return (
-        <Text key={b} color={isSelected ? 'magenta' : undefined} bold={isSelected}>
+        <Text key={b} bold={isSelected} color={isSelected ? 'yellow' : undefined}>
           {isSelected ? '> ' : '  '}
           {b}
         </Text>
       );
     })}
-    <Text dimColor>[↑/↓] Choose   [Enter] Select & Re-analyze   [Esc] Cancel</Text>
+    <Text dimColor>[↑/↓] Choose   [Enter] Select & Re-analyze   [Esc] Back</Text>
   </Box>
 );
 
@@ -301,7 +302,7 @@ const ConfirmDialog: React.FC<{
     </Text>
     <Text>
       Press <Text bold color="green">[y]</Text> to execute, or{' '}
-      <Text bold color="red">[n / Esc]</Text> to cancel.
+      <Text bold color="red">[n / Esc]</Text> to go Back.
     </Text>
   </Box>
 );
@@ -314,6 +315,7 @@ export function AnalyzeDashboard({
   initialOptions,
   initialResult,
   onExit,
+  onBack,
 }: AnalyzeDashboardProps) {
   const { exit } = useApp();
   const [options, setOptions] = useState<AnalysisOptions>(() => ({
@@ -443,7 +445,17 @@ export function AnalyzeDashboard({
       return;
     }
 
-    // Default dashboard controls
+    // Back or Exit dashboard controls
+    if (key.escape) {
+      if (onBack) {
+        onBack();
+      } else {
+        onExit?.();
+        exit();
+      }
+      return;
+    }
+
     if (input === 'q' || (key.ctrl && input === 'c')) {
       onExit?.();
       exit();
@@ -530,7 +542,7 @@ export function AnalyzeDashboard({
 
       <Box marginTop={1}>
         <Text dimColor>
-          [↑/↓] Navigate  [f] Fix  [e] Explain  [n] Namespace  [b] Backend  [r] Refresh  [q] Quit
+          [↑/↓] Navigate  [f] Fix  [e] Explain  [n] Namespace  [b] Backend  [r] Refresh  [Esc] Back  [q] Quit
         </Text>
       </Box>
     </Box>

--- a/src/ui/AuthDashboard.tsx
+++ b/src/ui/AuthDashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
 import { getAIConfig, setAIConfig } from '../config/store';
 import { type AIProviderConfig } from '../config/schema';
+import { triggerBack, triggerExit } from './navigation-utils';
 
 const VALID_BACKENDS = [
   'openai',
@@ -493,21 +494,11 @@ export const AuthDashboard: React.FC<AuthDashboardProps> = ({ onBack, onExit }) 
       return;
     }
     if (key.escape || lowerInput === 'b') {
-      if (onBack) {
-        onBack();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerBack(onBack, exit);
       return;
     }
     if (lowerInput === 'q' || (key.ctrl && input === 'c')) {
-      if (onExit) {
-        onExit();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerExit(onExit, exit);
       return;
     }
   };

--- a/src/ui/AuthDashboard.tsx
+++ b/src/ui/AuthDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useApp } from 'ink';
 import { getAIConfig, setAIConfig } from '../config/store';
 import { type AIProviderConfig } from '../config/schema';
 
@@ -143,6 +143,8 @@ const ProviderList = ({
             <Text> Set Default  </Text>
             <Text bold>[R]</Text>
             <Text> Remove  </Text>
+            <Text bold>[Esc/B]</Text>
+            <Text> Back  </Text>
             <Text bold>[Q]</Text>
             <Text> Quit</Text>
           </Box>
@@ -216,7 +218,7 @@ const WizardForm = ({ title, steps, activeStep, errorMsg }: WizardFormProps) => 
       )}
 
       <Text dimColor>
-        [ENTER] Next/Submit   [ESC] Cancel   [↑/↓] Change fields
+        [ENTER] Next/Submit   [ESC] Back   [↑/↓] Change fields
       </Text>
     </Box>
   );
@@ -242,7 +244,7 @@ const RemoveConfirm = ({ selectedProviderName }: RemoveConfirmProps) => {
       </Box>
       <Text>
         Press <Text bold color="green">[Y]</Text> to confirm, or{' '}
-        <Text bold color="red">[N]</Text> (or Esc) to cancel.
+        <Text bold color="red">[N]</Text> (or Esc) to go Back.
       </Text>
     </Box>
   );
@@ -250,7 +252,13 @@ const RemoveConfirm = ({ selectedProviderName }: RemoveConfirmProps) => {
 
 // --- Main AuthDashboard Component ---
 
-export const AuthDashboard = () => {
+export interface AuthDashboardProps {
+  onBack?: () => void;
+  onExit?: () => void;
+}
+
+export const AuthDashboard: React.FC<AuthDashboardProps> = ({ onBack, onExit }) => {
+  const { exit } = useApp();
   const [config, setConfig] = useState(() => getAIConfig());
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [mode, setMode] = useState<Mode>('list');
@@ -484,8 +492,23 @@ export const AuthDashboard = () => {
       selectRemoveProvider();
       return;
     }
-    if (lowerInput === 'q') {
-      process.exit(0);
+    if (key.escape || lowerInput === 'b') {
+      if (onBack) {
+        onBack();
+      } else {
+        exit();
+        process.exit(0);
+      }
+      return;
+    }
+    if (lowerInput === 'q' || (key.ctrl && input === 'c')) {
+      if (onExit) {
+        onExit();
+      } else {
+        exit();
+        process.exit(0);
+      }
+      return;
     }
   };
 

--- a/src/ui/HealthDashboard.tsx
+++ b/src/ui/HealthDashboard.tsx
@@ -1,15 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useApp } from 'ink';
 import { getRunningPods, PodData } from '../kubernetes/pods';
 import { getRunningContainers, ContainerData } from '../docker/containers';
 import { getK8sClusterStats } from '../kubernetes/pods';
 import { getDockerSystemStats } from '../docker/containers';
 import chalk from 'chalk';
 
-interface HealthDashboardProps {
+export interface HealthDashboardProps {
   initialTarget: string;
   initialWatch?: boolean;
   initialInterval?: number;
+  onBack?: () => void;
+  onExit?: () => void;
 }
 
 interface SelectableItem {
@@ -271,7 +273,10 @@ export const HealthDashboard: React.FC<HealthDashboardProps> = ({
   initialTarget,
   initialWatch = false,
   initialInterval = 5,
+  onBack,
+  onExit,
 }) => {
+  const { exit } = useApp();
   const [target, setTarget] = useState(initialTarget);
   const [watch, setWatch] = useState(initialWatch);
   const [interval, setIntervalVal] = useState(initialInterval);
@@ -377,8 +382,29 @@ export const HealthDashboard: React.FC<HealthDashboardProps> = ({
   useInput((input, key) => {
     const lowerInput = input.toLowerCase();
 
+    if (key.escape || lowerInput === 'b') {
+      const hasInspected = Object.values(inspectedIds).some(Boolean);
+      if (hasInspected) {
+        setInspectedIds({});
+        return;
+      }
+      if (onBack) {
+        onBack();
+      } else {
+        exit();
+        process.exit(0);
+      }
+      return;
+    }
+
     if (lowerInput === 'q' || (key.ctrl && input === 'c')) {
-      process.exit(0);
+      if (onExit) {
+        onExit();
+      } else {
+        exit();
+        process.exit(0);
+      }
+      return;
     }
 
     if (key.tab) {
@@ -454,7 +480,7 @@ export const HealthDashboard: React.FC<HealthDashboardProps> = ({
       {/* Help Bar */}
       <Box marginTop={1} borderStyle="single" borderColor="gray" paddingX={1}>
         <Text dimColor>
-          TAB: Target ({target.toUpperCase()}) | SPACE: Expand/Collapse | W: Watch ({watch ? 'ON' : 'OFF'}) | +/-: Interval ({interval}s) | ENTER: Inspect | Q: Quit
+          TAB: Target ({target.toUpperCase()}) | SPACE: Expand/Collapse | W: Watch ({watch ? 'ON' : 'OFF'}) | +/-: Interval ({interval}s) | ENTER: Inspect | [Esc/B] Back | [Q] Quit
         </Text>
       </Box>
     </Box>

--- a/src/ui/HealthDashboard.tsx
+++ b/src/ui/HealthDashboard.tsx
@@ -5,6 +5,7 @@ import { getRunningContainers, ContainerData } from '../docker/containers';
 import { getK8sClusterStats } from '../kubernetes/pods';
 import { getDockerSystemStats } from '../docker/containers';
 import chalk from 'chalk';
+import { triggerBack, triggerExit } from './navigation-utils';
 
 export interface HealthDashboardProps {
   initialTarget: string;
@@ -269,6 +270,18 @@ const getNextTarget = (prev: string): string => {
   return 'all';
 };
 
+const calculateCompositePercent = (
+  showK8s: boolean,
+  showDocker: boolean,
+  k8sVal: number,
+  dockerVal: number
+): number => {
+  if (showK8s && showDocker) {
+    return (k8sVal + dockerVal) / 2;
+  }
+  return showK8s ? k8sVal : dockerVal;
+};
+
 export const HealthDashboard: React.FC<HealthDashboardProps> = ({
   initialTarget,
   initialWatch = false,
@@ -351,23 +364,9 @@ export const HealthDashboard: React.FC<HealthDashboardProps> = ({
   const showK8s = target === 'all' || target === 'pods';
   const showDocker = target === 'all' || target === 'containers';
 
-  const cpuPercent = showK8s && showDocker
-    ? (k8sCpu + dockerCpu) / 2
-    : showK8s
-    ? k8sCpu
-    : dockerCpu;
-
-  const memPercent = showK8s && showDocker
-    ? (k8sMem + dockerMem) / 2
-    : showK8s
-    ? k8sMem
-    : dockerMem;
-
-  const workloadPercent = showK8s && showDocker
-    ? (podsPercent + containersPercent) / 2
-    : showK8s
-    ? podsPercent
-    : containersPercent;
+  const cpuPercent = calculateCompositePercent(showK8s, showDocker, k8sCpu, dockerCpu);
+  const memPercent = calculateCompositePercent(showK8s, showDocker, k8sMem, dockerMem);
+  const workloadPercent = calculateCompositePercent(showK8s, showDocker, podsPercent, containersPercent);
 
   const selectableItems = buildSelectableItems(
     showK8s,
@@ -388,22 +387,12 @@ export const HealthDashboard: React.FC<HealthDashboardProps> = ({
         setInspectedIds({});
         return;
       }
-      if (onBack) {
-        onBack();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerBack(onBack, exit);
       return;
     }
 
     if (lowerInput === 'q' || (key.ctrl && input === 'c')) {
-      if (onExit) {
-        onExit();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerExit(onExit, exit);
       return;
     }
 

--- a/src/ui/InitialDashboard.tsx
+++ b/src/ui/InitialDashboard.tsx
@@ -1,0 +1,349 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { checkDockerConnection } from '../docker/client';
+import { checkK8sConnection } from '../kubernetes/client';
+import { checkMinikubeConnection } from '../minikube/client';
+
+/**
+ * Docker connection status summary.
+ */
+export interface DockerSummary {
+  connected: boolean;
+  containerCount: number;
+}
+
+/**
+ * Kubernetes connection status summary.
+ */
+export interface K8sSummary {
+  connected: boolean;
+  podCount: number;
+}
+
+/**
+ * Minikube connection status summary.
+ */
+export interface MinikubeSummary {
+  installed: boolean;
+  running: boolean;
+}
+
+/**
+ * Interactive menu action definition.
+ */
+export interface MenuAction {
+  id: string;
+  key: string;
+  name: string;
+  cmd: string;
+  description: string;
+  args: string[];
+}
+
+/**
+ * Props for the InitialDashboard component.
+ */
+export interface InitialDashboardProps {
+  version: string;
+  onSelect?: (args: string[]) => void;
+  onExit?: () => void;
+  initialDocker?: DockerSummary;
+  initialK8s?: K8sSummary;
+  initialMinikube?: MinikubeSummary;
+}
+
+const MENU_ACTIONS: MenuAction[] = [
+  {
+    id: 'analyze',
+    key: 'a',
+    name: '🔍 Analyze Cluster',
+    cmd: 'kdm analyze',
+    description: 'Diagnose Kubernetes workloads for failures and review remediation suggestions',
+    args: ['analyze'],
+  },
+  {
+    id: 'show',
+    key: 's',
+    name: '📊 Show Resources',
+    cmd: 'kdm show runners',
+    description: 'Interactive dashboard to inspect running pods, containers, and runners',
+    args: ['show', 'runners'],
+  },
+  {
+    id: 'watch',
+    key: 'w',
+    name: '⏱️  Live Watch',
+    cmd: 'kdm watch',
+    description: 'Live real-time monitoring of cluster resources and containers',
+    args: ['watch'],
+  },
+  {
+    id: 'health',
+    key: 'h',
+    name: '🩺 Health Status',
+    cmd: 'kdm health all',
+    description: 'Evaluate health checks and readiness probes across all workloads',
+    args: ['health', 'all'],
+  },
+  {
+    id: 'logs',
+    key: 'l',
+    name: '📜 View Logs',
+    cmd: 'kdm logs',
+    description: 'Search, filter, and stream container and pod log output',
+    args: ['logs'],
+  },
+  {
+    id: 'auth',
+    key: 'k',
+    name: '🔑 AI Provider Config',
+    cmd: 'kdm auth',
+    description: 'Configure AI diagnosis backends, credentials, and models',
+    args: ['auth'],
+  },
+  {
+    id: 'help',
+    key: '?',
+    name: '❓ CLI Help',
+    cmd: 'kdm --help',
+    description: 'Display command-line flags, options, and full help documentation',
+    args: ['--help'],
+  },
+  {
+    id: 'exit',
+    key: 'q',
+    name: '🚪 Exit',
+    cmd: 'exit',
+    description: 'Exit KDM interactive dashboard',
+    args: [],
+  },
+];
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/**
+ * Lightweight inline spinner to display async operations.
+ */
+const InkSpinner: React.FC = () => {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setFrame((f) => (f + 1) % SPINNER_FRAMES.length), 80);
+    return () => clearInterval(timer);
+  }, []);
+  return <Text color="cyan">{SPINNER_FRAMES[frame]}</Text>;
+};
+
+/**
+ * Renders the top ASCII logo banner and version label.
+ */
+const HeaderBanner: React.FC<{ version: string }> = ({ version }) => (
+  <Box flexDirection="column" marginBottom={1}>
+    <Text color="cyan">  ██╗  ██╗██████╗ ███╗   ███╗</Text>
+    <Text color="cyan">  ██║ ██╔╝██╔══██╗████╗ ████║</Text>
+    <Text color="cyan">  █████╔╝ ██║  ██║██╔████╔██║</Text>
+    <Text color="cyan">  ██╔═██╗ ██║  ██║██║╚██╔╝██║</Text>
+    <Text color="cyan">  ██║  ██╗██████╔╝██║ ╚═╝ ██║</Text>
+    <Text color="cyan">  ╚═╝  ╚═╝╚═════╝ ╚═╝     ╚═╝</Text>
+    <Text dimColor>  ──────────────────────────────────────────────────</Text>
+    <Text bold color="blue">  Kubernetes & Docker Monitor v{version}</Text>
+  </Box>
+);
+
+/**
+ * Connection badge helper with appropriate color coding.
+ */
+const ConnectionBadge: React.FC<{ label: string; active: boolean; warn?: boolean }> = ({
+  label,
+  active,
+  warn,
+}) => {
+  if (active) {
+    return <Text bold color="green">{label}</Text>;
+  }
+  if (warn) {
+    return <Text bold color="yellow">{label}</Text>;
+  }
+  return <Text bold color="red">{label}</Text>;
+};
+
+/**
+ * Displays status cards for Docker, Kubernetes, and Minikube connections.
+ */
+const ConnectionPanel: React.FC<{
+  loading: boolean;
+  docker: DockerSummary | null;
+  k8s: K8sSummary | null;
+  minikube: MinikubeSummary | null;
+}> = ({ loading, docker, k8s, minikube }) => {
+  const minikubeLabel = minikube?.installed ? (minikube.running ? 'RUNNING' : 'STOPPED') : 'NOT INSTALLED';
+  const minikubeWarn = minikube?.installed && !minikube.running;
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+      marginBottom={1}
+    >
+      <Box justifyContent="space-between" marginBottom={1}>
+        <Text bold color="cyan">Cluster & Service Status</Text>
+        {loading && (
+          <Text color="yellow">
+            <InkSpinner /> Checking connections...
+          </Text>
+        )}
+      </Box>
+      <Box flexDirection="row" justifyContent="space-between">
+        <Box flexDirection="column" width="33%">
+          <Text bold>Docker:</Text>
+          <Box flexDirection="row" gap={1}>
+            <ConnectionBadge
+              label={docker?.connected ? 'CONNECTED' : 'DISCONNECTED'}
+              active={Boolean(docker?.connected)}
+            />
+            <Text dimColor>({docker?.containerCount ?? 0} containers)</Text>
+          </Box>
+        </Box>
+        <Box flexDirection="column" width="33%">
+          <Text bold>Kubernetes:</Text>
+          <Box flexDirection="row" gap={1}>
+            <ConnectionBadge
+              label={k8s?.connected ? 'CONNECTED' : 'DISCONNECTED'}
+              active={Boolean(k8s?.connected)}
+            />
+            <Text dimColor>({k8s?.podCount ?? 0} pods)</Text>
+          </Box>
+        </Box>
+        <Box flexDirection="column" width="33%">
+          <Text bold>Minikube:</Text>
+          <ConnectionBadge
+            label={minikubeLabel}
+            active={Boolean(minikube?.running)}
+            warn={minikubeWarn}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+/**
+ * Renders the command menu with navigation highlight.
+ */
+const MenuList: React.FC<{
+  items: MenuAction[];
+  selectedIndex: number;
+}> = ({ items, selectedIndex }) => (
+  <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} marginBottom={1}>
+    <Text bold color="yellow" marginBottom={1}>Select an Action to Launch:</Text>
+    {items.map((item, idx) => {
+      const isSelected = idx === selectedIndex;
+      return (
+        <Box key={item.id} flexDirection="row" justifyContent="space-between">
+          <Text bold={isSelected} color={isSelected ? 'cyan' : undefined}>
+            {isSelected ? '> ' : '  '}
+            {item.name}
+          </Text>
+          <Text dimColor>[{item.cmd}]</Text>
+        </Box>
+      );
+    })}
+  </Box>
+);
+
+/**
+ * Shows details and description for the currently selected command.
+ */
+const SelectedPreview: React.FC<{ item: MenuAction }> = ({ item }) => (
+  <Box flexDirection="column" paddingX={1} marginBottom={1}>
+    <Text bold color="green">Action Details:</Text>
+    <Text>  Command: <Text bold color="cyan">{item.cmd}</Text></Text>
+    <Text dimColor>  {item.description}</Text>
+  </Box>
+);
+
+/**
+ * Interactive initial home dashboard for KDM CLI.
+ */
+export const InitialDashboard: React.FC<InitialDashboardProps> = ({
+  version,
+  onSelect,
+  onExit,
+  initialDocker,
+  initialK8s,
+  initialMinikube,
+}) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [docker, setDocker] = useState<DockerSummary | null>(initialDocker ?? null);
+  const [k8s, setK8s] = useState<K8sSummary | null>(initialK8s ?? null);
+  const [minikube, setMinikube] = useState<MinikubeSummary | null>(initialMinikube ?? null);
+
+  const fetchStatus = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [d, k, m] = await Promise.all([
+        checkDockerConnection(),
+        checkK8sConnection(),
+        checkMinikubeConnection(),
+      ]);
+      setDocker(d);
+      setK8s(k);
+      setMinikube(m);
+    } catch {
+      // Graceful fallback on connection errors
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!initialDocker && !initialK8s && !initialMinikube) {
+      void fetchStatus();
+    }
+  }, [fetchStatus, initialDocker, initialK8s, initialMinikube]);
+
+  const handleExecute = useCallback((action: MenuAction) => {
+    if (action.id === 'exit') {
+      onExit?.();
+    } else {
+      onSelect?.(action.args);
+    }
+  }, [onExit, onSelect]);
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+    } else if (key.downArrow) {
+      setSelectedIndex((i) => Math.min(MENU_ACTIONS.length - 1, i + 1));
+    } else if (key.return) {
+      handleExecute(MENU_ACTIONS[selectedIndex]);
+    } else if (input === 'r') {
+      void fetchStatus();
+    } else if (input === 'q' || key.escape) {
+      onExit?.();
+    } else {
+      const matched = MENU_ACTIONS.find((item) => item.key === input);
+      if (matched) {
+        handleExecute(matched);
+      }
+    }
+  });
+
+  const selectedItem = MENU_ACTIONS[selectedIndex];
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <HeaderBanner version={version} />
+      <ConnectionPanel loading={loading} docker={docker} k8s={k8s} minikube={minikube} />
+      <MenuList items={MENU_ACTIONS} selectedIndex={selectedIndex} />
+      <SelectedPreview item={selectedItem} />
+      <Box borderStyle="single" borderColor="gray" paddingX={1}>
+        <Text dimColor>
+          [↑/↓] Navigate   [Enter] Launch   [a] Analyze   [s] Show   [w] Watch   [r] Refresh   [q] Quit
+        </Text>
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/InitialDashboard.tsx
+++ b/src/ui/InitialDashboard.tsx
@@ -174,6 +174,27 @@ const ConnectionBadge: React.FC<{ label: string; active: boolean; warn?: boolean
 };
 
 /**
+ * Renders an individual service status card.
+ */
+interface StatusCardProps {
+  title: string;
+  label: string;
+  active: boolean;
+  warn?: boolean;
+  detail?: string;
+}
+
+const StatusCard: React.FC<StatusCardProps> = ({ title, label, active, warn, detail }) => (
+  <Box flexDirection="column" width="33%">
+    <Text bold>{title}:</Text>
+    <Box flexDirection="row" gap={1}>
+      <ConnectionBadge label={label} active={active} warn={warn} />
+      {detail && <Text dimColor>({detail})</Text>}
+    </Box>
+  </Box>
+);
+
+/**
  * Displays status cards for Docker, Kubernetes, and Minikube connections.
  */
 const ConnectionPanel: React.FC<{
@@ -183,7 +204,7 @@ const ConnectionPanel: React.FC<{
   minikube: MinikubeSummary | null;
 }> = ({ loading, docker, k8s, minikube }) => {
   const minikubeLabel = minikube?.installed ? (minikube.running ? 'RUNNING' : 'STOPPED') : 'NOT INSTALLED';
-  const minikubeWarn = minikube?.installed && !minikube.running;
+  const minikubeWarn = Boolean(minikube?.installed && !minikube.running);
 
   return (
     <Box
@@ -202,34 +223,24 @@ const ConnectionPanel: React.FC<{
         )}
       </Box>
       <Box flexDirection="row" justifyContent="space-between">
-        <Box flexDirection="column" width="33%">
-          <Text bold>Docker:</Text>
-          <Box flexDirection="row" gap={1}>
-            <ConnectionBadge
-              label={docker?.connected ? 'CONNECTED' : 'DISCONNECTED'}
-              active={Boolean(docker?.connected)}
-            />
-            <Text dimColor>({docker?.containerCount ?? 0} containers)</Text>
-          </Box>
-        </Box>
-        <Box flexDirection="column" width="33%">
-          <Text bold>Kubernetes:</Text>
-          <Box flexDirection="row" gap={1}>
-            <ConnectionBadge
-              label={k8s?.connected ? 'CONNECTED' : 'DISCONNECTED'}
-              active={Boolean(k8s?.connected)}
-            />
-            <Text dimColor>({k8s?.podCount ?? 0} pods)</Text>
-          </Box>
-        </Box>
-        <Box flexDirection="column" width="33%">
-          <Text bold>Minikube:</Text>
-          <ConnectionBadge
-            label={minikubeLabel}
-            active={Boolean(minikube?.running)}
-            warn={minikubeWarn}
-          />
-        </Box>
+        <StatusCard
+          title="Docker"
+          label={docker?.connected ? 'CONNECTED' : 'DISCONNECTED'}
+          active={Boolean(docker?.connected)}
+          detail={`${docker?.containerCount ?? 0} containers`}
+        />
+        <StatusCard
+          title="Kubernetes"
+          label={k8s?.connected ? 'CONNECTED' : 'DISCONNECTED'}
+          active={Boolean(k8s?.connected)}
+          detail={`${k8s?.podCount ?? 0} pods`}
+        />
+        <StatusCard
+          title="Minikube"
+          label={minikubeLabel}
+          active={Boolean(minikube?.running)}
+          warn={minikubeWarn}
+        />
       </Box>
     </Box>
   );
@@ -243,7 +254,9 @@ const MenuList: React.FC<{
   selectedIndex: number;
 }> = ({ items, selectedIndex }) => (
   <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} marginBottom={1}>
-    <Text bold color="yellow" marginBottom={1}>Select an Action to Launch:</Text>
+    <Box marginBottom={1}>
+      <Text bold color="yellow">Select an Action to Launch:</Text>
+    </Box>
     {items.map((item, idx) => {
       const isSelected = idx === selectedIndex;
       return (
@@ -258,6 +271,21 @@ const MenuList: React.FC<{
     })}
   </Box>
 );
+
+/**
+ * Determines whether cluster connections should be fetched asynchronously.
+ * Skips fetching only when all three initial status objects are supplied.
+ */
+export function shouldFetchStatus(
+  docker?: DockerSummary,
+  k8s?: K8sSummary,
+  minikube?: MinikubeSummary
+): boolean {
+  if (!docker) return true;
+  if (!k8s) return true;
+  if (!minikube) return true;
+  return false;
+}
 
 /**
  * Shows details and description for the currently selected command.
@@ -364,7 +392,7 @@ export const InitialDashboard: React.FC<InitialDashboardProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!initialDocker && !initialK8s && !initialMinikube) {
+    if (shouldFetchStatus(initialDocker, initialK8s, initialMinikube)) {
       void fetchStatus();
     }
   }, [fetchStatus, initialDocker, initialK8s, initialMinikube]);

--- a/src/ui/InitialDashboard.tsx
+++ b/src/ui/InitialDashboard.tsx
@@ -195,6 +195,47 @@ const StatusCard: React.FC<StatusCardProps> = ({ title, label, active, warn, det
 );
 
 /**
+ * Helper to build status card model for Docker.
+ */
+function getDockerCard(docker: DockerSummary | null): StatusCardProps {
+  const isConnected = docker ? docker.connected : false;
+  const count = docker ? docker.containerCount : 0;
+  return {
+    title: 'Docker',
+    label: isConnected ? 'CONNECTED' : 'DISCONNECTED',
+    active: isConnected,
+    detail: `${count} containers`,
+  };
+}
+
+/**
+ * Helper to build status card model for Kubernetes.
+ */
+function getK8sCard(k8s: K8sSummary | null): StatusCardProps {
+  const isConnected = k8s ? k8s.connected : false;
+  const count = k8s ? k8s.podCount : 0;
+  return {
+    title: 'Kubernetes',
+    label: isConnected ? 'CONNECTED' : 'DISCONNECTED',
+    active: isConnected,
+    detail: `${count} pods`,
+  };
+}
+
+/**
+ * Helper to build status card model for Minikube.
+ */
+function getMinikubeCard(minikube: MinikubeSummary | null): StatusCardProps {
+  if (!minikube || !minikube.installed) {
+    return { title: 'Minikube', label: 'NOT INSTALLED', active: false };
+  }
+  if (minikube.running) {
+    return { title: 'Minikube', label: 'RUNNING', active: true };
+  }
+  return { title: 'Minikube', label: 'STOPPED', active: false, warn: true };
+}
+
+/**
  * Displays status cards for Docker, Kubernetes, and Minikube connections.
  */
 const ConnectionPanel: React.FC<{
@@ -202,49 +243,29 @@ const ConnectionPanel: React.FC<{
   docker: DockerSummary | null;
   k8s: K8sSummary | null;
   minikube: MinikubeSummary | null;
-}> = ({ loading, docker, k8s, minikube }) => {
-  const minikubeLabel = minikube?.installed ? (minikube.running ? 'RUNNING' : 'STOPPED') : 'NOT INSTALLED';
-  const minikubeWarn = Boolean(minikube?.installed && !minikube.running);
-
-  return (
-    <Box
-      flexDirection="column"
-      borderStyle="round"
-      borderColor="cyan"
-      paddingX={1}
-      marginBottom={1}
-    >
-      <Box justifyContent="space-between" marginBottom={1}>
-        <Text bold color="cyan">Cluster & Service Status</Text>
-        {loading && (
-          <Text color="yellow">
-            <InkSpinner /> Checking connections...
-          </Text>
-        )}
-      </Box>
-      <Box flexDirection="row" justifyContent="space-between">
-        <StatusCard
-          title="Docker"
-          label={docker?.connected ? 'CONNECTED' : 'DISCONNECTED'}
-          active={Boolean(docker?.connected)}
-          detail={`${docker?.containerCount ?? 0} containers`}
-        />
-        <StatusCard
-          title="Kubernetes"
-          label={k8s?.connected ? 'CONNECTED' : 'DISCONNECTED'}
-          active={Boolean(k8s?.connected)}
-          detail={`${k8s?.podCount ?? 0} pods`}
-        />
-        <StatusCard
-          title="Minikube"
-          label={minikubeLabel}
-          active={Boolean(minikube?.running)}
-          warn={minikubeWarn}
-        />
-      </Box>
+}> = ({ loading, docker, k8s, minikube }) => (
+  <Box
+    flexDirection="column"
+    borderStyle="round"
+    borderColor="cyan"
+    paddingX={1}
+    marginBottom={1}
+  >
+    <Box justifyContent="space-between" marginBottom={1}>
+      <Text bold color="cyan">Cluster & Service Status</Text>
+      {loading && (
+        <Text color="yellow">
+          <InkSpinner /> Checking connections...
+        </Text>
+      )}
     </Box>
-  );
-};
+    <Box flexDirection="row" justifyContent="space-between">
+      <StatusCard {...getDockerCard(docker)} />
+      <StatusCard {...getK8sCard(k8s)} />
+      <StatusCard {...getMinikubeCard(minikube)} />
+    </Box>
+  </Box>
+);
 
 /**
  * Renders the command menu with navigation highlight.
@@ -326,6 +347,21 @@ const HelpScreen: React.FC<{ onBack: () => void }> = ({ onBack }) => {
   );
 };
 
+const SUB_SCREENS: Record<
+  string,
+  (onBack: () => void, onExit?: () => void) => React.ReactNode
+> = {
+  analyze: (onBack, onExit) => (
+    <AnalyzeDashboard initialOptions={{ output: 'text' }} onBack={onBack} onExit={onExit} />
+  ),
+  show: (onBack, onExit) => <ShowDashboard onBack={onBack} onExit={onExit} />,
+  watch: (onBack, onExit) => <WatchDashboard onBack={onBack} onExit={onExit} />,
+  health: (onBack, onExit) => <HealthDashboard initialTarget="all" onBack={onBack} onExit={onExit} />,
+  logs: (onBack, onExit) => <LogsDashboard onBack={onBack} onExit={onExit} />,
+  auth: (onBack, onExit) => <AuthDashboard onBack={onBack} onExit={onExit} />,
+  help: (onBack) => <HelpScreen onBack={onBack} />,
+};
+
 /**
  * Renders the active sub-dashboard screen with a Back button back to home.
  */
@@ -334,25 +370,47 @@ const renderSubScreen = (
   onBack: () => void,
   onExit?: () => void
 ): React.ReactNode => {
-  switch (activeScreen) {
-    case 'analyze':
-      return <AnalyzeDashboard initialOptions={{ output: 'text' }} onBack={onBack} onExit={onExit} />;
-    case 'show':
-      return <ShowDashboard onBack={onBack} onExit={onExit} />;
-    case 'watch':
-      return <WatchDashboard onBack={onBack} onExit={onExit} />;
-    case 'health':
-      return <HealthDashboard initialTarget="all" onBack={onBack} onExit={onExit} />;
-    case 'logs':
-      return <LogsDashboard onBack={onBack} onExit={onExit} />;
-    case 'auth':
-      return <AuthDashboard onBack={onBack} onExit={onExit} />;
-    case 'help':
-      return <HelpScreen onBack={onBack} />;
-    default:
-      return null;
-  }
+  const screenRenderer = SUB_SCREENS[activeScreen];
+  return screenRenderer ? screenRenderer(onBack, onExit) : null;
 };
+
+/**
+ * Handles keyboard input for main menu navigation and execution.
+ */
+function handleMenuKeyInput(
+  input: string,
+  key: { upArrow?: boolean; downArrow?: boolean; return?: boolean; escape?: boolean },
+  selectedIndex: number,
+  setSelectedIndex: React.Dispatch<React.SetStateAction<number>>,
+  onExecute: (action: MenuAction) => void,
+  onRefresh: () => void,
+  onExit?: () => void
+): void {
+  if (key.upArrow) {
+    setSelectedIndex((i) => Math.max(0, i - 1));
+    return;
+  }
+  if (key.downArrow) {
+    setSelectedIndex((i) => Math.min(MENU_ACTIONS.length - 1, i + 1));
+    return;
+  }
+  if (key.return) {
+    onExecute(MENU_ACTIONS[selectedIndex]);
+    return;
+  }
+  if (input === 'r') {
+    onRefresh();
+    return;
+  }
+  if (input === 'q' || key.escape) {
+    onExit?.();
+    return;
+  }
+  const matched = MENU_ACTIONS.find((item) => item.key === input);
+  if (matched) {
+    onExecute(matched);
+  }
+}
 
 /**
  * Interactive initial home dashboard for KDM CLI.
@@ -407,23 +465,16 @@ export const InitialDashboard: React.FC<InitialDashboardProps> = ({
   }, [onExit, onSelect]);
 
   useInput((input, key) => {
-    if (activeScreen !== 'home') return;
-
-    if (key.upArrow) {
-      setSelectedIndex((i) => Math.max(0, i - 1));
-    } else if (key.downArrow) {
-      setSelectedIndex((i) => Math.min(MENU_ACTIONS.length - 1, i + 1));
-    } else if (key.return) {
-      handleExecute(MENU_ACTIONS[selectedIndex]);
-    } else if (input === 'r') {
-      void fetchStatus();
-    } else if (input === 'q' || key.escape) {
-      onExit?.();
-    } else {
-      const matched = MENU_ACTIONS.find((item) => item.key === input);
-      if (matched) {
-        handleExecute(matched);
-      }
+    if (activeScreen === 'home') {
+      handleMenuKeyInput(
+        input,
+        key,
+        selectedIndex,
+        setSelectedIndex,
+        handleExecute,
+        () => void fetchStatus(),
+        onExit
+      );
     }
   });
 

--- a/src/ui/InitialDashboard.tsx
+++ b/src/ui/InitialDashboard.tsx
@@ -3,6 +3,12 @@ import { Box, Text, useInput } from 'ink';
 import { checkDockerConnection } from '../docker/client';
 import { checkK8sConnection } from '../kubernetes/client';
 import { checkMinikubeConnection } from '../minikube/client';
+import { AnalyzeDashboard } from './AnalyzeDashboard';
+import { WatchDashboard } from './WatchDashboard';
+import { HealthDashboard } from './HealthDashboard';
+import { ShowDashboard } from './show/ShowDashboard';
+import { LogsDashboard } from './LogsDashboard';
+import { AuthDashboard } from './AuthDashboard';
 
 /**
  * Docker connection status summary.
@@ -50,6 +56,7 @@ export interface InitialDashboardProps {
   initialDocker?: DockerSummary;
   initialK8s?: K8sSummary;
   initialMinikube?: MinikubeSummary;
+  initialScreen?: string;
 }
 
 const MENU_ACTIONS: MenuAction[] = [
@@ -264,6 +271,62 @@ const SelectedPreview: React.FC<{ item: MenuAction }> = ({ item }) => (
 );
 
 /**
+ * Screen displaying KDM CLI help documentation with back action.
+ */
+const HelpScreen: React.FC<{ onBack: () => void }> = ({ onBack }) => {
+  useInput((input, key) => {
+    if (key.escape || input.toLowerCase() === 'b' || input.toLowerCase() === 'q') {
+      onBack();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" padding={1} borderStyle="round" borderColor="cyan">
+      <Text bold color="cyan" marginBottom={1}>KDM - Kubernetes & Docker Monitoring CLI Help</Text>
+      <Text bold color="yellow">Available Commands:</Text>
+      <Text>  kdm analyze        - Analyze Kubernetes resources for common workload problems</Text>
+      <Text>  kdm show [target]  - Show running containers, pods, or runners</Text>
+      <Text>  kdm watch          - Live monitoring mode using Ink split-pane dashboard</Text>
+      <Text>  kdm health [target]- Show health status for pods, containers, or all</Text>
+      <Text>  kdm logs [name]    - Search and stream container and pod logs</Text>
+      <Text>  kdm auth           - Manage AI provider authentication and credentials</Text>
+      <Text>  kdm config         - Manage KDM configuration</Text>
+      <Box marginTop={1} borderStyle="single" borderColor="gray" paddingX={1}>
+        <Text dimColor>[Esc/B] Back to Main Menu   [Q] Back</Text>
+      </Box>
+    </Box>
+  );
+};
+
+/**
+ * Renders the active sub-dashboard screen with a Back button back to home.
+ */
+const renderSubScreen = (
+  activeScreen: string,
+  onBack: () => void,
+  onExit?: () => void
+): React.ReactNode => {
+  switch (activeScreen) {
+    case 'analyze':
+      return <AnalyzeDashboard initialOptions={{ output: 'text' }} onBack={onBack} onExit={onExit} />;
+    case 'show':
+      return <ShowDashboard onBack={onBack} onExit={onExit} />;
+    case 'watch':
+      return <WatchDashboard onBack={onBack} onExit={onExit} />;
+    case 'health':
+      return <HealthDashboard initialTarget="all" onBack={onBack} onExit={onExit} />;
+    case 'logs':
+      return <LogsDashboard onBack={onBack} onExit={onExit} />;
+    case 'auth':
+      return <AuthDashboard onBack={onBack} onExit={onExit} />;
+    case 'help':
+      return <HelpScreen onBack={onBack} />;
+    default:
+      return null;
+  }
+};
+
+/**
  * Interactive initial home dashboard for KDM CLI.
  */
 export const InitialDashboard: React.FC<InitialDashboardProps> = ({
@@ -273,7 +336,9 @@ export const InitialDashboard: React.FC<InitialDashboardProps> = ({
   initialDocker,
   initialK8s,
   initialMinikube,
+  initialScreen = 'home',
 }) => {
+  const [activeScreen, setActiveScreen] = useState<string>(initialScreen);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [loading, setLoading] = useState(false);
   const [docker, setDocker] = useState<DockerSummary | null>(initialDocker ?? null);
@@ -305,14 +370,17 @@ export const InitialDashboard: React.FC<InitialDashboardProps> = ({
   }, [fetchStatus, initialDocker, initialK8s, initialMinikube]);
 
   const handleExecute = useCallback((action: MenuAction) => {
+    onSelect?.(action.args);
     if (action.id === 'exit') {
       onExit?.();
     } else {
-      onSelect?.(action.args);
+      setActiveScreen(action.id);
     }
   }, [onExit, onSelect]);
 
   useInput((input, key) => {
+    if (activeScreen !== 'home') return;
+
     if (key.upArrow) {
       setSelectedIndex((i) => Math.max(0, i - 1));
     } else if (key.downArrow) {
@@ -331,6 +399,14 @@ export const InitialDashboard: React.FC<InitialDashboardProps> = ({
     }
   });
 
+  if (activeScreen !== 'home') {
+    return (
+      <Box flexDirection="column">
+        {renderSubScreen(activeScreen, () => setActiveScreen('home'), onExit)}
+      </Box>
+    );
+  }
+
   const selectedItem = MENU_ACTIONS[selectedIndex];
 
   return (
@@ -341,7 +417,7 @@ export const InitialDashboard: React.FC<InitialDashboardProps> = ({
       <SelectedPreview item={selectedItem} />
       <Box borderStyle="single" borderColor="gray" paddingX={1}>
         <Text dimColor>
-          [↑/↓] Navigate   [Enter] Launch   [a] Analyze   [s] Show   [w] Watch   [r] Refresh   [q] Quit
+          [↑/↓] Navigate   [Enter] Launch   [a] Analyze   [s] Show   [w] Watch   [r] Refresh   [Esc/q] Quit
         </Text>
       </Box>
     </Box>

--- a/src/ui/LogsDashboard.tsx
+++ b/src/ui/LogsDashboard.tsx
@@ -6,6 +6,7 @@ import { getRunningContainers, ContainerData } from '../docker/containers';
 import { getK8sApi } from '../kubernetes/client';
 import { getDockerClient } from '../docker/client';
 import chalk from 'chalk';
+import { triggerBack, triggerExit } from './navigation-utils';
 
 export interface LogsDashboardProps {
   initialName?: string;
@@ -247,24 +248,14 @@ export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName, onBac
     }
 
     if (lowerInput === 'q' || (key.ctrl && input === 'c')) {
-      if (onExit) {
-        onExit();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerExit(onExit, exit);
       return;
     }
 
     // Selector Mode keys
     if (!selectedResource) {
       if (key.escape || (!searchQuery && lowerInput === 'b')) {
-        if (onBack) {
-          onBack();
-        } else {
-          exit();
-          process.exit(0);
-        }
+        triggerBack(onBack, exit);
         return;
       }
       if (key.upArrow) {
@@ -294,12 +285,7 @@ export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName, onBac
         setLogSearchQuery('');
         setSearchMode(false);
       } else {
-        if (onBack) {
-          onBack();
-        } else {
-          exit();
-          process.exit(0);
-        }
+        triggerBack(onBack, exit);
       }
       return;
     }

--- a/src/ui/LogsDashboard.tsx
+++ b/src/ui/LogsDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useApp } from 'ink';
 import TextInput from 'ink-text-input';
 import { getRunningPods, PodData } from '../kubernetes/pods';
 import { getRunningContainers, ContainerData } from '../docker/containers';
@@ -7,8 +7,10 @@ import { getK8sApi } from '../kubernetes/client';
 import { getDockerClient } from '../docker/client';
 import chalk from 'chalk';
 
-interface LogsDashboardProps {
+export interface LogsDashboardProps {
   initialName?: string;
+  onBack?: () => void;
+  onExit?: () => void;
 }
 
 interface SelectorResource {
@@ -61,7 +63,8 @@ const findPodMatch = (pods: PodData[], name: string): SelectorResource | null =>
   };
 };
 
-export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName }) => {
+export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName, onBack, onExit }) => {
+  const { exit } = useApp();
   // Stage 1: Resource Selector state
   const [resources, setResources] = useState<SelectorResource[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -244,11 +247,26 @@ export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName }) => 
     }
 
     if (lowerInput === 'q' || (key.ctrl && input === 'c')) {
-      process.exit(0);
+      if (onExit) {
+        onExit();
+      } else {
+        exit();
+        process.exit(0);
+      }
+      return;
     }
 
     // Selector Mode keys
     if (!selectedResource) {
+      if (key.escape || (!searchQuery && lowerInput === 'b')) {
+        if (onBack) {
+          onBack();
+        } else {
+          exit();
+          process.exit(0);
+        }
+        return;
+      }
       if (key.upArrow) {
         setSelectedIndex(prev => Math.max(0, prev - 1));
         return;
@@ -268,7 +286,7 @@ export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName }) => 
     }
 
     // Log Viewer Mode keys
-    if (key.escape) {
+    if (key.escape || lowerInput === 'b') {
       // Go back to selector if it wasn't pre-specified
       if (!initialName) {
         setSelectedResource(null);
@@ -276,7 +294,12 @@ export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName }) => 
         setLogSearchQuery('');
         setSearchMode(false);
       } else {
-        process.exit(0);
+        if (onBack) {
+          onBack();
+        } else {
+          exit();
+          process.exit(0);
+        }
       }
       return;
     }
@@ -351,7 +374,7 @@ export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName }) => 
           )}
         </Box>
         <Box marginTop={1} borderStyle="single" borderColor="gray" paddingX={1}>
-          <Text dimColor>↑↓: Navigate | ENTER: Select | Q: Quit</Text>
+          <Text dimColor>↑↓: Navigate | ENTER: Select | [Esc/B] Back | [Q] Quit</Text>
         </Box>
       </Box>
     );
@@ -430,7 +453,7 @@ export const LogsDashboard: React.FC<LogsDashboardProps> = ({ initialName }) => 
 
       <Box marginTop={1} borderStyle="single" borderColor="gray" paddingX={1}>
         <Text dimColor>
-          SPACE: {streaming ? 'Pause' : 'Resume'} | /: Search | T: Timestamps ({showTimestamps ? 'ON' : 'OFF'}) | {logSearchQuery ? 'n/N: Match | ' : ''}ESC: Back | Q: Quit
+          SPACE: {streaming ? 'Pause' : 'Resume'} | /: Search | T: Timestamps ({showTimestamps ? 'ON' : 'OFF'}) | {logSearchQuery ? 'n/N: Match | ' : ''}[Esc/B] Back | [Q] Quit
         </Text>
       </Box>
     </Box>

--- a/src/ui/WatchDashboard.tsx
+++ b/src/ui/WatchDashboard.tsx
@@ -7,6 +7,7 @@ import { getDockerClient } from '../docker/client';
 import { createAIClient } from '../ai/factory';
 import { getAIConfig } from '../config/store';
 import chalk from 'chalk';
+import { triggerBack, triggerExit } from './navigation-utils';
 
 const StatusBadge = ({ status, type }: { status: string, type: 'pod' | 'container' }) => {
   const isRunning = type === 'pod' ? status === 'Running' : status === 'running';
@@ -260,22 +261,12 @@ export const WatchDashboard: React.FC<WatchDashboardProps> = ({ onBack, onExit }
     }
 
     if (key.escape || lowerInput === 'b') {
-      if (onBack) {
-        onBack();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerBack(onBack, exit);
       return;
     }
 
     if (lowerInput === 'q' || (key.ctrl && input === 'c')) {
-      if (onExit) {
-        onExit();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerExit(onExit, exit);
       return;
     }
 

--- a/src/ui/WatchDashboard.tsx
+++ b/src/ui/WatchDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useApp } from 'ink';
 import { getRunningPods, PodData, getK8sClusterStats, K8sClusterStats } from '../kubernetes/pods';
 import { getRunningContainers, ContainerData, getDockerSystemStats, DockerSystemStats, formatDockerBytes } from '../docker/containers';
 import { getK8sApi } from '../kubernetes/client';
@@ -27,7 +27,13 @@ export const truncateName = (name: string, maxLength: number): string => {
   return name.substring(0, maxLength - 3) + '...';
 };
 
-export const WatchDashboard = () => {
+export interface WatchDashboardProps {
+  onBack?: () => void;
+  onExit?: () => void;
+}
+
+export const WatchDashboard: React.FC<WatchDashboardProps> = ({ onBack, onExit }) => {
+  const { exit } = useApp();
   const [pods, setPods] = useState<PodData[]>([]);
   const [containers, setContainers] = useState<ContainerData[]>([]);
   const [k8sStats, setK8sStats] = useState<K8sClusterStats | null>(null);
@@ -240,14 +246,37 @@ export const WatchDashboard = () => {
     }
 
     if (aiDiagnosis) {
-      if (key.escape || lowerInput === 'q') {
+      if (key.escape || lowerInput === 'q' || lowerInput === 'b') {
         setAiDiagnosis(null);
       }
       return;
     }
 
+    if (showLogs) {
+      if (key.escape || lowerInput === 'q' || lowerInput === 'b') {
+        setShowLogs(false);
+      }
+      return;
+    }
+
+    if (key.escape || lowerInput === 'b') {
+      if (onBack) {
+        onBack();
+      } else {
+        exit();
+        process.exit(0);
+      }
+      return;
+    }
+
     if (lowerInput === 'q' || (key.ctrl && input === 'c')) {
-      process.exit(0);
+      if (onExit) {
+        onExit();
+      } else {
+        exit();
+        process.exit(0);
+      }
+      return;
     }
 
     // Switch focus
@@ -308,7 +337,7 @@ export const WatchDashboard = () => {
       <Box flexDirection="column" padding={1} borderStyle="round" borderColor="cyan">
         <Box justifyContent="space-between" marginBottom={1}>
           <Text bold color="cyan"> Logs: {selectedResource?.name} [STREAMING] </Text>
-          <Text dimColor>Press ESC or Q to go back</Text>
+          <Text dimColor>Press [ESC/B] Back</Text>
         </Box>
         <Box borderStyle="single" borderColor="gray" minHeight={15} padding={1} flexDirection="column">
           {loadingLogs ? (
@@ -327,7 +356,7 @@ export const WatchDashboard = () => {
       <Box flexDirection="column" padding={1} borderStyle="round" borderColor="magenta">
         <Box justifyContent="space-between" marginBottom={1}>
           <Text bold color="magenta"> AI Diagnosis for {selectedResource?.name} </Text>
-          <Text dimColor>Press ESC or Q to go back</Text>
+          <Text dimColor>Press [ESC/B] Back</Text>
         </Box>
         <Box borderStyle="single" borderColor="gray" minHeight={12} padding={1}>
           <Text color="white">{aiDiagnosis}</Text>
@@ -483,7 +512,7 @@ export const WatchDashboard = () => {
 
       {/* Footer / Shortcuts */}
       <Box marginTop={1}>
-        <Text bold>[L] Logs  [A] AI Analysis  [R] Restart  [TAB] Switch Focus  [Q] Quit</Text>
+        <Text bold>[L] Logs  [A] AI Analysis  [R] Restart  [TAB] Switch Focus  [Esc/B] Back  [Q] Quit</Text>
       </Box>
     </Box>
   );

--- a/src/ui/navigation-utils.ts
+++ b/src/ui/navigation-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Utility functions for navigation and exit handling across interactive dashboards.
+ */
+
+/**
+ * Executes the onBack callback if provided; otherwise unmounts and exits the process.
+ *
+ * @param onBack - Optional callback to navigate back to a parent screen.
+ * @param exitFn - Optional Ink useApp exit unmount function.
+ */
+export function triggerBack(onBack?: () => void, exitFn?: () => void): void {
+  if (onBack) {
+    onBack();
+    return;
+  }
+  exitFn?.();
+  process.exit(0);
+}
+
+/**
+ * Executes the onExit callback if provided; otherwise unmounts and exits the process.
+ *
+ * @param onExit - Optional callback to handle CLI process termination.
+ * @param exitFn - Optional Ink useApp exit unmount function.
+ */
+export function triggerExit(onExit?: () => void, exitFn?: () => void): void {
+  if (onExit) {
+    onExit();
+    return;
+  }
+  exitFn?.();
+  process.exit(0);
+}

--- a/src/ui/show/DetailOverlay.tsx
+++ b/src/ui/show/DetailOverlay.tsx
@@ -104,7 +104,7 @@ export const DetailOverlay: React.FC<DetailOverlayProps> = ({ resource, onClose 
             </Box>
           ))}
         </Box>
-        <Text dimColor>  Press ESC to close</Text>
+        <Text dimColor>  Press [ESC/B] Back</Text>
       </Box>
     </Box>
   );

--- a/src/ui/show/HelpBar.tsx
+++ b/src/ui/show/HelpBar.tsx
@@ -9,7 +9,7 @@ export const HelpBar: React.FC = () => (
       <Text bold color="yellow">/</Text><Text dimColor> Search  </Text>
       <Text bold color="yellow">↑↓</Text><Text dimColor> Navigate  </Text>
       <Text bold color="yellow">Enter</Text><Text dimColor> Details  </Text>
-      <Text bold color="yellow">Esc</Text><Text dimColor> Close  </Text>
+      <Text bold color="yellow">Esc</Text><Text dimColor> Back  </Text>
       <Text bold color="yellow">Q</Text><Text dimColor> Quit</Text>
     </Text>
   </Box>

--- a/src/ui/show/ShowDashboard.tsx
+++ b/src/ui/show/ShowDashboard.tsx
@@ -11,6 +11,7 @@ import { getRunningContainers, ContainerData, getDockerSystemStats, DockerSystem
 import { listNodes } from '../../kubernetes/resources';
 import { getMinikubeStatus } from '../../minikube/client';
 import type * as k8s from '@kubernetes/client-node';
+import { triggerBack, triggerExit } from '../navigation-utils';
 
 const columnConfigs: Record<TabType, Column[]> = {
   [TabType.Pods]: [
@@ -272,22 +273,12 @@ export const ShowDashboard: React.FC<ShowDashboardProps> = ({ onBack, onExit }) 
     }
 
     if (key.escape || input.toLowerCase() === 'b') {
-      if (onBack) {
-        onBack();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerBack(onBack, exit);
       return;
     }
 
     if (input.toLowerCase() === 'q' || (key.ctrl && input === 'c')) {
-      if (onExit) {
-        onExit();
-      } else {
-        exit();
-        process.exit(0);
-      }
+      triggerExit(onExit, exit);
       return;
     }
 

--- a/src/ui/show/ShowDashboard.tsx
+++ b/src/ui/show/ShowDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useApp } from 'ink';
 import { TabType, TabConfig, Column, ResourceRow, PodRow, ContainerRow, NodeRow, RunnerRow, MinikubeRow, DataError } from './types';
 import { TabBar } from './TabBar';
 import { SearchInput } from './SearchInput';
@@ -133,7 +133,13 @@ const ErrorBanner: React.FC<{ errors: DataError[] }> = ({ errors }) => {
   );
 };
 
-export const ShowDashboard: React.FC = () => {
+export interface ShowDashboardProps {
+  onBack?: () => void;
+  onExit?: () => void;
+}
+
+export const ShowDashboard: React.FC<ShowDashboardProps> = ({ onBack, onExit }) => {
+  const { exit } = useApp();
   const [activeTab, setActiveTab] = useState<TabType>(TabType.Pods);
   const [selectedRow, setSelectedRow] = useState(0);
   const [searchQuery, setSearchQuery] = useState('');
@@ -253,12 +259,36 @@ export const ShowDashboard: React.FC = () => {
 
   useInput((input, key) => {
     if (showDetail) {
-      if (key.escape) setShowDetail(false);
+      if (key.escape || input.toLowerCase() === 'b') setShowDetail(false);
+      return;
+    }
+
+    if (showSearch) {
+      if (key.escape) {
+        setShowSearch(false);
+        setSearchQuery('');
+      }
+      return;
+    }
+
+    if (key.escape || input.toLowerCase() === 'b') {
+      if (onBack) {
+        onBack();
+      } else {
+        exit();
+        process.exit(0);
+      }
       return;
     }
 
     if (input.toLowerCase() === 'q' || (key.ctrl && input === 'c')) {
-      process.exit(0);
+      if (onExit) {
+        onExit();
+      } else {
+        exit();
+        process.exit(0);
+      }
+      return;
     }
 
     if (key.tab || key.rightArrow) {


### PR DESCRIPTION
## Why
Running `kdm` without arguments previously produced a static console output before immediately exiting. Converting this entry point into an interactive TUI dashboard provides a central launchpad for users to view cluster connection health and seamlessly navigate to primary monitoring and diagnostics workflows without having to memorize subcommands. Furthermore, each screen, overlay, and sub-dashboard now supports a dedicated Back button/keybinding (`Esc` / `b`) to enable smooth navigation back to parent screens and menus without terminating the CLI process.

## What changed
- Created `InitialDashboard.tsx` using Ink:
  - Header banner with ASCII branding and version information
  - Live status cards for Docker, Kubernetes, and Minikube with container/pod counts
  - Interactive Action Launcher to navigate and launch core commands (`kdm analyze`, `kdm show runners`, `kdm watch`, `kdm health all`, `kdm logs`, `kdm auth`, `kdm --help`)
  - Internal screen router allowing in-process transition between the main menu and sub-dashboards with instant return on `Esc` or `b`
  - Live in-place connection refresh (`r`) with animated spinner
  - Direct keyboard shortcuts (`a`, `s`, `w`, `h`, `l`, `k`, `?`, `q`/`Esc`)
- Added Back navigation support across all screens, sub-views, and modals:
  - **Analyze Dashboard** (`src/ui/AnalyzeDashboard.tsx`): `[Esc] Back` on main view triggers `onBack`; Namespace modal, Backend modal, and Confirmation dialog explicitly indicate and handle Back.
  - **Health Dashboard** (`src/ui/HealthDashboard.tsx`): `[Esc/B] Back` closes inspected service details or returns to parent dashboard.
  - **Watch Dashboard** (`src/ui/WatchDashboard.tsx`): `[ESC/B] Back` closes active log streaming or AI diagnosis overlay or returns to parent dashboard.
  - **Show Dashboard** (`src/ui/show/ShowDashboard.tsx`, `HelpBar.tsx`, `DetailOverlay.tsx`): `[Esc/B] Back` closes resource detail overlay or returns to parent dashboard.
  - **Logs Dashboard** (`src/ui/LogsDashboard.tsx`): `[Esc/B] Back` returns from log streaming back to pod selector, or from selector back to parent dashboard.
  - **Auth Dashboard** (`src/ui/AuthDashboard.tsx`): `[Esc/B] Back` cancels provider wizard/removal dialog or returns from provider list to parent dashboard.
- Updated `src/commands/root.ts`:
  - Automatically launches `InitialDashboard` in interactive TTY sessions
  - Preserves deterministic static output for non-interactive (CI / piped stdout) environments
- Added unit tests in `src/__tests__/initial-dashboard.test.tsx` covering navigation, shortcut dispatch, internal sub-screen navigation, Back button keybindings (`Esc` / `b`), connection refresh, and clean exit.

## Testing
- Verified interactive navigation and action execution in terminal with smooth Back transitions.
- Ran full test suite (`npm test`): 28 test files passed (360 tests passed).
- Built project (`npm run build`) cleanly.