### PR TITLE
[KDM-TEST-FEAT-242] feat: add interactive custom analyzer manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ kdm filters remove Ingress  # Remove analyzer from active list (falls back to de
 Register custom scripts/commands or HTTP webhooks to analyze arbitrary custom resources (CRDs) like Kyverno, KEDA, and Prometheus.
 
 ```bash
-kdm custom-analyzer                                                        # Interactive rule manager
+kdm custom-analyzer                                                        # Interactive rule manager (TTY required)
 kdm custom-analyzer add keda --command "kubectl get scaledobjects -A -o json" # Add custom analyzer command
 kdm custom-analyzer add my-webhook --url "https://api.my-org.internal/check"  # Add custom HTTP analyzer
 kdm custom-analyzer list                                                     # List all custom analyzers

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ kdm filters remove Ingress  # Remove analyzer from active list (falls back to de
 Register custom scripts/commands or HTTP webhooks to analyze arbitrary custom resources (CRDs) like Kyverno, KEDA, and Prometheus.
 
 ```bash
+kdm custom-analyzer                                                        # Interactive rule manager
 kdm custom-analyzer add keda --command "kubectl get scaledobjects -A -o json" # Add custom analyzer command
 kdm custom-analyzer add my-webhook --url "https://api.my-org.internal/check"  # Add custom HTTP analyzer
 kdm custom-analyzer list                                                     # List all custom analyzers

--- a/commands.md
+++ b/commands.md
@@ -201,6 +201,8 @@ Register custom shell commands or HTTP webhooks to analyze arbitrary custom reso
 
 Running `kdm custom-analyzer` opens an interactive rule manager. Use the arrow keys to select a
 rule, `a` to open the add wizard, `d` or `Delete` to remove the selected rule, and `q` to quit.
+The dashboard requires a TTY terminal and exits with code 1 otherwise. Press `Esc` to cancel the
+add wizard.
 
 The legacy subcommands remain available for scripts:
 

--- a/commands.md
+++ b/commands.md
@@ -199,7 +199,10 @@ kdm filters add Ingress
 ## 9. `kdm custom-analyzer`
 Register custom shell commands or HTTP webhooks to analyze arbitrary custom resources (CRDs).
 
-### Subcommands:
+Running `kdm custom-analyzer` opens an interactive rule manager. Use the arrow keys to select a
+rule, `a` to open the add wizard, `d` or `Delete` to remove the selected rule, and `q` to quit.
+
+The legacy subcommands remain available for scripts:
 
 - **`kdm custom-analyzer add <name>`**
   Register a new analyzer. Requires either `--command` or `--url`.

--- a/src/__tests__/custom-analyzer-dashboard.test.tsx
+++ b/src/__tests__/custom-analyzer-dashboard.test.tsx
@@ -40,9 +40,12 @@ const wait = () => new Promise((resolve) => setTimeout(resolve, 30));
 describe('CustomAnalyzerDashboard', () => {
   let stdin: MockStdin;
   let stdout: MockStdout;
+  let app: ReturnType<typeof render> | undefined;
 
   afterEach(() => {
+    app?.unmount();
     stdin?.push(null);
+    app = undefined;
   });
 
   it('adds a command rule through the wizard and removes the selected rule', async () => {
@@ -56,7 +59,7 @@ describe('CustomAnalyzerDashboard', () => {
         1,
       );
     });
-    const app = render(
+    app = render(
       <CustomAnalyzerDashboard analyzers={analyzers} onAdd={onAdd} onRemove={onRemove} />,
       { stdin, stdout, interactive: true },
     );
@@ -82,9 +85,10 @@ describe('CustomAnalyzerDashboard', () => {
 
     stdin.send('d');
     await wait();
+    expect(onRemove).not.toHaveBeenCalled();
+    stdin.send('y');
+    await wait();
     expect(onRemove).toHaveBeenCalledWith('keda-check');
-
-    app.unmount();
   });
 
   it('validates webhook URLs', () => {
@@ -97,7 +101,7 @@ describe('CustomAnalyzerDashboard', () => {
   it('shows a validation error for an empty rule name', async () => {
     stdin = new MockStdin();
     stdout = new MockStdout();
-    const app = render(
+    app = render(
       <CustomAnalyzerDashboard
         analyzers={[{ name: 'existing', command: 'echo existing' }]}
         onAdd={vi.fn()}
@@ -115,14 +119,13 @@ describe('CustomAnalyzerDashboard', () => {
     await wait();
     stdin.send('\u001b');
     await wait();
-    app.unmount();
   });
 
   it('navigates and removes analyzers with keyboard controls', async () => {
     stdin = new MockStdin();
     stdout = new MockStdout();
     const onRemove = vi.fn();
-    const app = render(
+    app = render(
       <CustomAnalyzerDashboard
         analyzers={[
           { name: 'first', command: 'echo first' },
@@ -138,12 +141,89 @@ describe('CustomAnalyzerDashboard', () => {
     await wait();
     stdin.send('d');
     await wait();
+    expect(onRemove).not.toHaveBeenCalled();
+    stdin.send('n');
+    await wait();
+    expect(onRemove).not.toHaveBeenCalled();
+    stdin.send('d');
+    await wait();
+    stdin.send('y');
+    await wait();
     expect(onRemove).toHaveBeenCalledWith('second');
-    stdin.send('\u001b[3~');
+    stdin.send('d');
+    await wait();
+    stdin.send('y');
     await wait();
     expect(onRemove).toHaveBeenCalledWith('first');
     stdin.send('q');
     await wait();
-    app.unmount();
+  });
+
+  it('rejects duplicate names and cancels the wizard with Esc', async () => {
+    stdin = new MockStdin();
+    stdout = new MockStdout();
+    app = render(
+      <CustomAnalyzerDashboard
+        analyzers={[{ name: 'existing', command: 'echo existing' }]}
+        onAdd={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+      { stdin, stdout, interactive: true },
+    );
+
+    stdin.send('a');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    for (const character of 'existing') stdin.send(character);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    stdin.send('\r');
+    await wait();
+    expect(stdout.output).toContain('already exists');
+    stdin.send('\u001b');
+    await wait();
+    expect(stdout.output).toContain('Custom Analyzers');
+  });
+
+  it('adds a valid HTTPS webhook and rejects an invalid URL', async () => {
+    stdin = new MockStdin();
+    stdout = new MockStdout();
+    const onAdd = vi.fn();
+    app = render(
+      <CustomAnalyzerDashboard analyzers={[]} onAdd={onAdd} onRemove={vi.fn()} />,
+      { stdin, stdout, interactive: true },
+    );
+
+    stdin.send('a');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    for (const character of 'webhook') stdin.send(character);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    stdin.send('\r');
+    await wait();
+    stdin.send('\u001b[B');
+    await wait();
+    stdin.send('\r');
+    await wait();
+    for (const character of 'not-a-url') stdin.send(character);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    stdin.send('\r');
+    await wait();
+    expect(stdout.output).toContain('valid HTTP or HTTPS URL');
+    stdin.send('\u001b');
+    await wait();
+
+    stdin.send('a');
+    await wait();
+    for (const character of 'webhook') stdin.send(character);
+    await wait();
+    stdin.send('\r');
+    await wait();
+    stdin.send('\u001b[B');
+    await wait();
+    stdin.send('\r');
+    await wait();
+    for (const character of 'https://example.com/hook') stdin.send(character);
+    await wait();
+    stdin.send('\r');
+    await wait();
+    expect(onAdd).toHaveBeenCalledWith({ name: 'webhook', url: 'https://example.com/hook' });
   });
 });

--- a/src/__tests__/custom-analyzer-dashboard.test.tsx
+++ b/src/__tests__/custom-analyzer-dashboard.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'ink';
+import { Readable, Writable } from 'node:stream';
+import { Console } from 'node:console';
+import { CustomAnalyzerDashboard } from '../ui/CustomAnalyzerDashboard';
+
+if (!(console as any).Console) {
+  (console as any).Console = Console;
+}
+
+class MockStdout extends Writable {
+  output = '';
+  isTTY = true;
+  columns = 80;
+  rows = 24;
+
+  _write(chunk: any, _encoding: string, callback: (error?: Error | null) => void) {
+    this.output += chunk.toString();
+    callback();
+  }
+}
+
+class MockStdin extends Readable {
+  isTTY = true;
+  setRawMode = vi.fn();
+  setEncoding = vi.fn();
+  ref = vi.fn();
+  unref = vi.fn();
+
+  _read() {}
+
+  send(value: string) {
+    this.push(Buffer.from(value));
+  }
+}
+
+const wait = () => new Promise((resolve) => setTimeout(resolve, 30));
+
+describe('CustomAnalyzerDashboard', () => {
+  let stdin: MockStdin;
+  let stdout: MockStdout;
+
+  afterEach(() => {
+    stdin?.push(null);
+  });
+
+  it('adds a command rule through the wizard and removes the selected rule', async () => {
+    stdin = new MockStdin();
+    stdout = new MockStdout();
+    const analyzers: { name: string; command?: string }[] = [];
+    const onAdd = vi.fn((config) => analyzers.push(config));
+    const onRemove = vi.fn((name: string) => {
+      analyzers.splice(
+        analyzers.findIndex((analyzer) => analyzer.name === name),
+        1,
+      );
+    });
+    const app = render(
+      <CustomAnalyzerDashboard analyzers={analyzers} onAdd={onAdd} onRemove={onRemove} />,
+      { stdin, stdout, interactive: true },
+    );
+
+    stdin.send('a');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    for (const character of 'keda-check') stdin.send(character);
+    await wait();
+    stdin.send('\r');
+    await wait();
+    stdin.send('\r');
+    await wait();
+    for (const character of 'kubectl get scaledobjects -A -o json') stdin.send(character);
+    await wait();
+    stdin.send('\r');
+    await wait();
+
+    expect(onAdd).toHaveBeenCalledWith({
+      name: 'keda-check',
+      command: 'kubectl get scaledobjects -A -o json',
+    });
+    expect(stdout.output).toContain('keda-check');
+
+    stdin.send('d');
+    await wait();
+    expect(onRemove).toHaveBeenCalledWith('keda-check');
+
+    app.unmount();
+  });
+});

--- a/src/__tests__/custom-analyzer-dashboard.test.tsx
+++ b/src/__tests__/custom-analyzer-dashboard.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'ink';
 import { Readable, Writable } from 'node:stream';
 import { Console } from 'node:console';
-import { CustomAnalyzerDashboard } from '../ui/CustomAnalyzerDashboard';
+import { CustomAnalyzerDashboard, isValidUrl } from '../ui/CustomAnalyzerDashboard';
 
 if (!(console as any).Console) {
   (console as any).Console = Console;
@@ -84,6 +84,66 @@ describe('CustomAnalyzerDashboard', () => {
     await wait();
     expect(onRemove).toHaveBeenCalledWith('keda-check');
 
+    app.unmount();
+  });
+
+  it('validates webhook URLs', () => {
+    expect(isValidUrl('https://example.com/hook')).toBe(true);
+    expect(isValidUrl('http://localhost:8080')).toBe(true);
+    expect(isValidUrl('not-a-url')).toBe(false);
+    expect(isValidUrl('ftp://example.com')).toBe(false);
+  });
+
+  it('shows a validation error for an empty rule name', async () => {
+    stdin = new MockStdin();
+    stdout = new MockStdout();
+    const app = render(
+      <CustomAnalyzerDashboard
+        analyzers={[{ name: 'existing', command: 'echo existing' }]}
+        onAdd={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+      { stdin, stdout, interactive: true },
+    );
+
+    stdin.send('a');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    stdin.send('\r');
+    await wait();
+    expect(stdout.output).toContain('Rule name is required');
+    stdin.send('\u001b');
+    await wait();
+    stdin.send('\u001b');
+    await wait();
+    app.unmount();
+  });
+
+  it('navigates and removes analyzers with keyboard controls', async () => {
+    stdin = new MockStdin();
+    stdout = new MockStdout();
+    const onRemove = vi.fn();
+    const app = render(
+      <CustomAnalyzerDashboard
+        analyzers={[
+          { name: 'first', command: 'echo first' },
+          { name: 'second', url: 'https://example.com' },
+        ]}
+        onAdd={vi.fn()}
+        onRemove={onRemove}
+      />,
+      { stdin, stdout, interactive: true },
+    );
+
+    stdin.send('\u001b[B');
+    await wait();
+    stdin.send('d');
+    await wait();
+    expect(onRemove).toHaveBeenCalledWith('second');
+    stdin.send('\u001b[3~');
+    await wait();
+    expect(onRemove).toHaveBeenCalledWith('first');
+    stdin.send('q');
+    await wait();
     app.unmount();
   });
 });

--- a/src/commands/custom-analyzer.ts
+++ b/src/commands/custom-analyzer.ts
@@ -4,6 +4,9 @@ import { getConfig, setConfigValue } from '../config/store';
 import { createCustomAnalyzer, type CustomAnalyzerConfig } from '../analyzers/custom';
 import { registry } from '../analyzers';
 import { logger } from '../utils/logger';
+import React from 'react';
+import { render } from 'ink';
+import { CustomAnalyzerDashboard } from '../ui/CustomAnalyzerDashboard';
 
 /**
  * Retrieves the current custom analyzer configurations from the store.
@@ -91,7 +94,30 @@ async function handleRemove(name: string): Promise<void> {
 export const registerCustomAnalyzerCommand = (program: Command) => {
   const cmd = program
     .command('custom-analyzer')
-    .description('Manage custom analyzers');
+    .description('Manage custom analyzers')
+    .action(() => {
+      if (!process.stdout.isTTY || !process.stdin.isTTY) {
+        logger.error('Interactive custom analyzer dashboard requires a TTY terminal.');
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write('\x1Bc');
+      const instance = render(
+        React.createElement(CustomAnalyzerDashboard, {
+          analyzers: getCustomAnalyzers(),
+          onAdd: (config) => {
+            const analyzers = getCustomAnalyzers();
+            analyzers.push(config);
+            saveCustomAnalyzers(analyzers);
+            registry.register(createCustomAnalyzer(config));
+          },
+          onRemove: (name) => {
+            saveCustomAnalyzers(getCustomAnalyzers().filter((analyzer) => analyzer.name !== name));
+          },
+        }),
+      );
+      return instance.waitUntilExit();
+    });
 
   cmd
     .command('add <name>')

--- a/src/commands/custom-analyzer.ts
+++ b/src/commands/custom-analyzer.ts
@@ -101,7 +101,6 @@ export const registerCustomAnalyzerCommand = (program: Command) => {
         process.exitCode = 1;
         return;
       }
-      process.stdout.write('\x1Bc');
       const instance = render(
         React.createElement(CustomAnalyzerDashboard, {
           analyzers: getCustomAnalyzers(),
@@ -115,6 +114,7 @@ export const registerCustomAnalyzerCommand = (program: Command) => {
             saveCustomAnalyzers(getCustomAnalyzers().filter((analyzer) => analyzer.name !== name));
           },
         }),
+        { alternateScreen: true },
       );
       return instance.waitUntilExit();
     });

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -155,11 +155,10 @@ const run = async () => {
     return;
   }
 
-  program.parse(process.argv);
+  await program.parseAsync(process.argv);
 
   // Non-blocking version check (fires after command execution)
   checkForUpdates();
 };
 
 run();
-

--- a/src/ui/CustomAnalyzerDashboard.tsx
+++ b/src/ui/CustomAnalyzerDashboard.tsx
@@ -1,0 +1,175 @@
+import React, { useState } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+import type { CustomAnalyzerConfig } from '../analyzers/custom';
+
+type WizardStep = 1 | 2 | 3;
+type AnalyzerType = 'command' | 'url';
+
+interface CustomAnalyzerDashboardProps {
+  analyzers: CustomAnalyzerConfig[];
+  onAdd: (config: CustomAnalyzerConfig) => void;
+  onRemove: (name: string) => void;
+}
+
+const isValidUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const CustomAnalyzerDashboard: React.FC<CustomAnalyzerDashboardProps> = ({
+  analyzers,
+  onAdd,
+  onRemove,
+}) => {
+  const { exit } = useApp();
+  const [rules, setRules] = useState(analyzers);
+  const [selected, setSelected] = useState(0);
+  const [step, setStep] = useState<WizardStep | null>(null);
+  const [name, setName] = useState('');
+  const [type, setType] = useState<AnalyzerType>('command');
+  const [value, setValue] = useState('');
+  const [error, setError] = useState('');
+
+  const cancelWizard = () => {
+    setStep(null);
+    setName('');
+    setValue('');
+    setType('command');
+    setError('');
+  };
+
+  const submitStep = (input: string) => {
+    const trimmed = input.trim();
+    if (step === 1) {
+      if (!trimmed) {
+        setError('Rule name is required.');
+        return;
+      }
+      if (rules.some((analyzer) => analyzer.name === trimmed)) {
+        setError(`Rule "${trimmed}" already exists.`);
+        return;
+      }
+      setName(trimmed);
+      setError('');
+      setStep(2);
+      return;
+    }
+    if (step === 2) {
+      setError('');
+      setStep(3);
+      return;
+    }
+    if (!trimmed) {
+      setError(`${type === 'command' ? 'Command' : 'Webhook URL'} is required.`);
+      return;
+    }
+    if (type === 'url' && !isValidUrl(trimmed)) {
+      setError('Webhook URL must be a valid HTTP or HTTPS URL.');
+      return;
+    }
+    const config = type === 'command' ? { name, command: trimmed } : { name, url: trimmed };
+    setRules((current) => [...current, config]);
+    onAdd(config);
+    cancelWizard();
+  };
+
+  useInput((input, key) => {
+    if (key.escape) {
+      if (step !== null) cancelWizard();
+      else exit();
+      return;
+    }
+    if (step !== null) {
+      if (step === 2 && (key.upArrow || key.downArrow)) {
+        setType((current) => (current === 'command' ? 'url' : 'command'));
+      } else if (step === 2 && key.return) {
+        setError('');
+        setStep(3);
+      }
+      return;
+    }
+    if (key.upArrow && rules.length > 0) {
+      setSelected((current) => (current - 1 + rules.length) % rules.length);
+    } else if (key.downArrow && rules.length > 0) {
+      setSelected((current) => (current + 1) % rules.length);
+    } else if (input.toLowerCase() === 'a') {
+      setStep(1);
+      setError('');
+    } else if (input.toLowerCase() === 'd' || key.delete) {
+      const analyzer = rules[selected];
+      if (analyzer) {
+        onRemove(analyzer.name);
+        setRules((current) => current.filter((rule) => rule.name !== analyzer.name));
+        setSelected((current) => Math.min(current, Math.max(0, rules.length - 2)));
+      }
+    } else if (input.toLowerCase() === 'q') {
+      exit();
+    }
+  });
+
+  if (step !== null) {
+    return (
+      <Box borderStyle="round" flexDirection="column" padding={1} width={60}>
+        <Text bold>Add Custom Analyzer</Text>
+        <Text>Step {step}/3</Text>
+        {step === 1 ? (
+          <>
+            <Text>Rule name:</Text>
+            <TextInput value={name} onChange={setName} onSubmit={submitStep} />
+          </>
+        ) : step === 2 ? (
+          <>
+            <Text>Type (use ↑/↓, then Enter):</Text>
+            <Text color={type === 'command' ? 'cyan' : undefined}>
+              {type === 'command' ? '> ' : '  '}Command
+            </Text>
+            <Text color={type === 'url' ? 'cyan' : undefined}>
+              {type === 'url' ? '> ' : '  '}Webhook
+            </Text>
+            <Text dimColor>Enter Next • Esc Cancel</Text>
+          </>
+        ) : (
+          <>
+            <Text>{type === 'command' ? 'Command:' : 'Webhook URL:'}</Text>
+            <TextInput value={value} onChange={setValue} onSubmit={submitStep} />
+          </>
+        )}
+        {error ? <Text color="red">{error}</Text> : null}
+        {step !== 2 ? <Text dimColor>Enter Next • Esc Cancel</Text> : null}
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Box justifyContent="space-between">
+        <Text bold>Custom Analyzers</Text>
+        <Text>{rules.length} {rules.length === 1 ? 'rule' : 'rules'}</Text>
+      </Box>
+      <Text> </Text>
+      <Text>Name                 Type       Command / URL</Text>
+      <Text dimColor>{'─'.repeat(58)}</Text>
+      {rules.length === 0 ? (
+        <Text dimColor>No custom analyzers configured.</Text>
+      ) : (
+        rules.map((analyzer, index) => {
+          const analyzerType = analyzer.command ? 'Command' : 'Webhook';
+          const detail = analyzer.command ?? analyzer.url ?? '';
+          return (
+            <Text key={analyzer.name} color={index === selected ? 'cyan' : undefined}>
+              {index === selected ? '> ' : '  '}
+              {analyzer.name.padEnd(20).slice(0, 20)} {analyzerType.padEnd(10)} {detail}
+            </Text>
+          );
+        })
+      )}
+      <Text dimColor>{'─'.repeat(58)}</Text>
+      <Text>[A] Add Rule  [DELETE/D] Remove  [Q] Quit</Text>
+    </Box>
+  );
+};

--- a/src/ui/CustomAnalyzerDashboard.tsx
+++ b/src/ui/CustomAnalyzerDashboard.tsx
@@ -34,6 +34,7 @@ export const CustomAnalyzerDashboard: React.FC<CustomAnalyzerDashboardProps> = (
   const [type, setType] = useState<AnalyzerType>('command');
   const [value, setValue] = useState('');
   const [error, setError] = useState('');
+  const [pendingRemoval, setPendingRemoval] = useState<string | null>(null);
 
   const cancelWizard = () => {
     setStep(null);
@@ -79,6 +80,18 @@ export const CustomAnalyzerDashboard: React.FC<CustomAnalyzerDashboardProps> = (
   };
 
   useInput((input, key) => {
+    if (pendingRemoval) {
+      if (input.toLowerCase() === 'y') {
+        const removedName = pendingRemoval;
+        onRemove(removedName);
+        setRules((current) => current.filter((rule) => rule.name !== removedName));
+        setSelected((current) => Math.min(current, Math.max(0, rules.length - 2)));
+        setPendingRemoval(null);
+      } else if (input.toLowerCase() === 'n' || key.escape) {
+        setPendingRemoval(null);
+      }
+      return;
+    }
     if (key.escape) {
       if (step !== null) cancelWizard();
       else exit();
@@ -103,9 +116,7 @@ export const CustomAnalyzerDashboard: React.FC<CustomAnalyzerDashboardProps> = (
     } else if (input.toLowerCase() === 'd' || key.delete) {
       const analyzer = rules[selected];
       if (analyzer) {
-        onRemove(analyzer.name);
-        setRules((current) => current.filter((rule) => rule.name !== analyzer.name));
-        setSelected((current) => Math.min(current, Math.max(0, rules.length - 2)));
+        setPendingRemoval(analyzer.name);
       }
     } else if (input.toLowerCase() === 'q') {
       exit();
@@ -169,7 +180,11 @@ export const CustomAnalyzerDashboard: React.FC<CustomAnalyzerDashboardProps> = (
         })
       )}
       <Text dimColor>{'─'.repeat(58)}</Text>
-      <Text>[A] Add Rule  [DELETE/D] Remove  [Q] Quit</Text>
+      {pendingRemoval ? (
+        <Text color="yellow">Remove &quot;{pendingRemoval}&quot;? [y/N]</Text>
+      ) : (
+        <Text>[A] Add Rule  [DELETE/D] Remove  [Q] Quit</Text>
+      )}
     </Box>
   );
 };

--- a/src/ui/CustomAnalyzerDashboard.tsx
+++ b/src/ui/CustomAnalyzerDashboard.tsx
@@ -12,7 +12,7 @@ interface CustomAnalyzerDashboardProps {
   onRemove: (name: string) => void;
 }
 
-const isValidUrl = (value: string): boolean => {
+export const isValidUrl = (value: string): boolean => {
   try {
     const url = new URL(value);
     return url.protocol === 'http:' || url.protocol === 'https:';


### PR DESCRIPTION
## Summary

Closes #143

- Replace the default `kdm custom-analyzer` behavior with an interactive Ink rule manager.
- Add a table view showing analyzer name, type, and command or webhook URL.
- Add keyboard navigation with arrow keys, `a` to add, `d`/`Delete` to remove, and `q`/`Esc` to quit.
- Add a three-step creation wizard for rule name, analyzer type, and command or webhook URL.
- Validate required fields, duplicate names, and HTTP/HTTPS webhook URLs before saving.
- Preserve the existing `add`, `list`, and `remove` subcommands for scripts and backward compatibility.
- Update the README and command reference with the interactive workflow.

## Validation

- `npm run build`
- `npm test -- --run src/__tests__/custom-analyzer-dashboard.test.tsx`
- Existing `auth-dashboard` Ink regression tests also pass.

## User experience

The dashboard requires an interactive TTY. Non-interactive invocations receive an explicit error instead of silently falling back, while the legacy subcommands remain available for automation.