### PR TITLE
[KDM-TEST-FEAT-246] feat(filters): add interactive TUI checklist dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ kdm cache purge             # Clear all cached AI explanations
 
 ### Analyzer Filters
 
-By default, KDM runs all core resource analyzers. You can customize which analyzers are active.
+By default, KDM runs all core resource analyzers. You can customize which analyzers are active using the interactive checklist dashboard or CLI subcommands:
 
 ```bash
+kdm filters                 # Open interactive checklist dashboard with instant persistence
 kdm filters list            # List active filters and available inactive ones
 kdm filters add Ingress     # Add Ingress analyzer to active default filters list
 kdm filters remove Ingress  # Remove analyzer from active list (falls back to defaults)

--- a/commands.md
+++ b/commands.md
@@ -178,7 +178,13 @@ kdm cache purge
 ---
 
 ## 8. `kdm filters`
-Configure default active analyzers to filter what `kdm analyze` checks.
+Configure default active analyzers to filter what `kdm analyze` checks. Running `kdm filters` opens an interactive checklist TUI dashboard.
+
+### Interactive Dashboard:
+Run `kdm filters` to open the interactive multi-select checklist:
+- **`↑` / `↓`**: Navigate analyzer list
+- **`Space`**: Toggle analyzer on/off (instantly auto-saved)
+- **`Q`**: Quit
 
 ### Subcommands:
 - **`kdm filters list`**
@@ -190,6 +196,7 @@ Configure default active analyzers to filter what `kdm analyze` checks.
 
 ### Examples:
 ```bash
+kdm filters                 # Open interactive checklist dashboard
 kdm filters list
 kdm filters add Ingress
 ```

--- a/src/__tests__/filters-dashboard.test.tsx
+++ b/src/__tests__/filters-dashboard.test.tsx
@@ -93,14 +93,18 @@ const waitForFrameToContain = async ({
 
 describe('Checkbox component', () => {
   let mockStdout: MockWritable;
+  let mockStdin: MockStdin;
 
   beforeEach(() => {
     mockStdout = new MockWritable();
+    mockStdin = new MockStdin();
   });
 
   it('renders checked and selected state', async () => {
     const { unmount } = render(<Checkbox label="Pod" checked={true} isSelected={true} />, {
       stdout: mockStdout as any,
+      stdin: mockStdin as any,
+      interactive: true,
     });
     await waitForFrameToContain({ mockStdout, substring: 'Pod' });
     const output = mockStdout.frames.join('\n');
@@ -113,6 +117,8 @@ describe('Checkbox component', () => {
   it('renders unchecked and unselected state', async () => {
     const { unmount } = render(<Checkbox label="Ingress" checked={false} isSelected={false} />, {
       stdout: mockStdout as any,
+      stdin: mockStdin as any,
+      interactive: true,
     });
     await waitForFrameToContain({ mockStdout, substring: 'Ingress' });
     const output = mockStdout.frames.join('\n');

--- a/src/__tests__/filters-dashboard.test.tsx
+++ b/src/__tests__/filters-dashboard.test.tsx
@@ -98,24 +98,28 @@ describe('Checkbox component', () => {
     mockStdout = new MockWritable();
   });
 
-  it('renders checked and selected state', () => {
-    render(<Checkbox label="Pod" checked={true} isSelected={true} />, {
+  it('renders checked and selected state', async () => {
+    const { unmount } = render(<Checkbox label="Pod" checked={true} isSelected={true} />, {
       stdout: mockStdout as any,
     });
+    await waitForFrameToContain({ mockStdout, substring: 'Pod' });
     const output = mockStdout.frames.join('\n');
     expect(output).toContain('> ');
     expect(output).toContain('[x]');
     expect(output).toContain('Pod');
+    unmount();
   });
 
-  it('renders unchecked and unselected state', () => {
-    render(<Checkbox label="Ingress" checked={false} isSelected={false} />, {
+  it('renders unchecked and unselected state', async () => {
+    const { unmount } = render(<Checkbox label="Ingress" checked={false} isSelected={false} />, {
       stdout: mockStdout as any,
     });
+    await waitForFrameToContain({ mockStdout, substring: 'Ingress' });
     const output = mockStdout.frames.join('\n');
     expect(output).not.toContain('> ');
     expect(output).toContain('[ ]');
     expect(output).toContain('Ingress');
+    unmount();
   });
 });
 
@@ -146,7 +150,7 @@ describe('FiltersDashboard', () => {
   ];
 
   it('renders initial state with default filters active', async () => {
-    render(
+    const { unmount } = render(
       <FiltersDashboard
         availableAnalyzers={sampleAnalyzers}
         initialActiveFilters={DEFAULT_FILTERS}
@@ -170,10 +174,11 @@ describe('FiltersDashboard', () => {
     expect(output).toContain('[ ] Ingress');
     expect(output).toContain('[x] PersistentVolumeClaim');
     expect(output).toContain('[x] Node');
+    unmount();
   });
 
   it('navigates list with arrow keys', async () => {
-    render(
+    const { unmount } = render(
       <FiltersDashboard
         availableAnalyzers={sampleAnalyzers}
         initialActiveFilters={['Pod', 'Deployment']}
@@ -201,12 +206,13 @@ describe('FiltersDashboard', () => {
 
     const lastRendered = [...mockStdout.frames].reverse().find((f) => f.includes('Analyzer Filters'));
     expect(lastRendered).toContain('Deployment');
+    unmount();
   });
 
   it('toggles an analyzer off with Space and persists immediately', async () => {
     const onSaveSpy = vi.fn();
 
-    render(
+    const { unmount } = render(
       <FiltersDashboard
         availableAnalyzers={sampleAnalyzers}
         initialActiveFilters={['Pod', 'Deployment']}
@@ -227,12 +233,13 @@ describe('FiltersDashboard', () => {
     await waitForFrameToContain({ mockStdout, substring: '[ ] Pod' });
 
     expect(onSaveSpy).toHaveBeenCalledWith(['Deployment']);
+    unmount();
   });
 
   it('toggles an analyzer on with Space and persists immediately', async () => {
     const onSaveSpy = vi.fn();
 
-    render(
+    const { unmount } = render(
       <FiltersDashboard
         availableAnalyzers={sampleAnalyzers}
         initialActiveFilters={['Pod']}
@@ -257,6 +264,7 @@ describe('FiltersDashboard', () => {
     await waitForFrameToContain({ mockStdout, substring: '[x] Deployment' });
 
     expect(onSaveSpy).toHaveBeenCalledWith(['Pod', 'Deployment']);
+    unmount();
   });
 
   it('exits cleanly on Q key', async () => {

--- a/src/__tests__/filters-dashboard.test.tsx
+++ b/src/__tests__/filters-dashboard.test.tsx
@@ -1,0 +1,287 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'ink';
+import { Writable, Readable } from 'node:stream';
+import { Console } from 'node:console';
+import { FiltersDashboard, DEFAULT_FILTERS } from '../ui/FiltersDashboard';
+import { Checkbox } from '../ui/Checkbox';
+
+if (!(console as any).Console) {
+  (console as any).Console = Console;
+}
+
+const { mockFilters } = vi.hoisted(() => ({
+  mockFilters: { active: [] as string[] },
+}));
+
+vi.mock('../config/store', () => ({
+  getActiveFilters: vi.fn(() => mockFilters.active),
+  setActiveFilters: vi.fn((filters: string[]) => {
+    mockFilters.active = filters;
+  }),
+  rawConfigStore: {
+    has: vi.fn(() => mockFilters.active.length > 0),
+  },
+}));
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+class MockWritable extends Writable {
+  frames: string[] = [];
+  isTTY = true;
+  columns = 80;
+  rows = 24;
+  _write(chunk: any, encoding: any, callback: (error?: Error | null) => void) {
+    this.frames.push(chunk.toString());
+    callback();
+  }
+}
+
+class MockStdin extends Readable {
+  _read() {}
+  isTTY = true;
+  setRawMode = vi.fn();
+  setEncoding = vi.fn();
+  ref = vi.fn();
+  unref = vi.fn();
+  write(data: any) {
+    this.push(Buffer.from(data));
+  }
+  sendKey({ name }: { name: string }) {
+    const sequences: Record<string, string> = {
+      up: '\u001b[A',
+      down: '\u001b[B',
+      return: '\r',
+      enter: '\r',
+      escape: '\u001b',
+      backspace: '\u007f',
+    };
+    const seq = sequences[name];
+    if (seq) {
+      this.write(seq);
+    }
+  }
+  sendChar({ char }: { char: string }) {
+    this.write(char);
+  }
+  sendStr({ str }: { str: string }) {
+    this.write(str);
+  }
+}
+
+const waitForFrameToContain = async ({
+  mockStdout,
+  substring,
+  timeout = 3000,
+}: {
+  mockStdout: MockWritable;
+  substring: string;
+  timeout?: number;
+}) => {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    const output = mockStdout.frames.join('\n');
+    if (output.includes(substring)) {
+      return;
+    }
+    await sleep(20);
+  }
+  throw new Error(
+    `Timed out waiting for "${substring}" to appear in stdout. Output was:\n${mockStdout.frames.join('\n')}`,
+  );
+};
+
+describe('Checkbox component', () => {
+  let mockStdout: MockWritable;
+
+  beforeEach(() => {
+    mockStdout = new MockWritable();
+  });
+
+  it('renders checked and selected state', () => {
+    render(<Checkbox label="Pod" checked={true} isSelected={true} />, {
+      stdout: mockStdout as any,
+    });
+    const output = mockStdout.frames.join('\n');
+    expect(output).toContain('> ');
+    expect(output).toContain('[x]');
+    expect(output).toContain('Pod');
+  });
+
+  it('renders unchecked and unselected state', () => {
+    render(<Checkbox label="Ingress" checked={false} isSelected={false} />, {
+      stdout: mockStdout as any,
+    });
+    const output = mockStdout.frames.join('\n');
+    expect(output).not.toContain('> ');
+    expect(output).toContain('[ ]');
+    expect(output).toContain('Ingress');
+  });
+});
+
+describe('FiltersDashboard', () => {
+  let mockStdout: MockWritable;
+  let mockStdin: MockStdin;
+
+  beforeEach(() => {
+    mockStdout = new MockWritable();
+    mockStdin = new MockStdin();
+    mockFilters.active = [];
+    vi.clearAllMocks();
+  });
+
+  const sampleAnalyzers = [
+    'Pod',
+    'Deployment',
+    'Service',
+    'Ingress',
+    'CronJob',
+    'StatefulSet',
+    'DaemonSet',
+    'ReplicaSet',
+    'PersistentVolumeClaim',
+    'NetworkPolicy',
+    'HPA',
+    'Node',
+  ];
+
+  it('renders initial state with default filters active', async () => {
+    render(
+      <FiltersDashboard
+        availableAnalyzers={sampleAnalyzers}
+        initialActiveFilters={DEFAULT_FILTERS}
+      />,
+      {
+        stdout: mockStdout as any,
+        stdin: mockStdin as any,
+        interactive: true,
+      },
+    );
+
+    await waitForFrameToContain({ mockStdout, substring: 'Analyzer Filters' });
+    await waitForFrameToContain({ mockStdout, substring: 'Active: 5 / 12' });
+    await waitForFrameToContain({ mockStdout, substring: 'SPACE:Toggle ↑↓:Navigate Q:Quit (changes auto-saved)' });
+
+    const output = mockStdout.frames.join('\n');
+    expect(output).toContain('> ');
+    expect(output).toContain('[x] Pod');
+    expect(output).toContain('[x] Deployment');
+    expect(output).toContain('[x] Service');
+    expect(output).toContain('[ ] Ingress');
+    expect(output).toContain('[x] PersistentVolumeClaim');
+    expect(output).toContain('[x] Node');
+  });
+
+  it('navigates list with arrow keys', async () => {
+    render(
+      <FiltersDashboard
+        availableAnalyzers={sampleAnalyzers}
+        initialActiveFilters={['Pod', 'Deployment']}
+      />,
+      {
+        stdout: mockStdout as any,
+        stdin: mockStdin as any,
+        interactive: true,
+      },
+    );
+
+    await waitForFrameToContain({ mockStdout, substring: 'Analyzer Filters' });
+
+    // Press down arrow to move to Deployment
+    mockStdin.sendKey({ name: 'down' });
+    await sleep(50);
+
+    // Press down arrow again to move to Service
+    mockStdin.sendKey({ name: 'down' });
+    await sleep(50);
+
+    // Press up arrow to move back to Deployment
+    mockStdin.sendKey({ name: 'up' });
+    await sleep(50);
+
+    const lastRendered = [...mockStdout.frames].reverse().find((f) => f.includes('Analyzer Filters'));
+    expect(lastRendered).toContain('Deployment');
+  });
+
+  it('toggles an analyzer off with Space and persists immediately', async () => {
+    const onSaveSpy = vi.fn();
+
+    render(
+      <FiltersDashboard
+        availableAnalyzers={sampleAnalyzers}
+        initialActiveFilters={['Pod', 'Deployment']}
+        onSave={onSaveSpy}
+      />,
+      {
+        stdout: mockStdout as any,
+        stdin: mockStdin as any,
+        interactive: true,
+      },
+    );
+
+    await waitForFrameToContain({ mockStdout, substring: 'Active: 2 / 12' });
+
+    // Cursor starts on Pod (index 0, active). Press SPACE to toggle Pod off.
+    mockStdin.sendChar({ char: ' ' });
+    await waitForFrameToContain({ mockStdout, substring: 'Active: 1 / 12' });
+    await waitForFrameToContain({ mockStdout, substring: '[ ] Pod' });
+
+    expect(onSaveSpy).toHaveBeenCalledWith(['Deployment']);
+  });
+
+  it('toggles an analyzer on with Space and persists immediately', async () => {
+    const onSaveSpy = vi.fn();
+
+    render(
+      <FiltersDashboard
+        availableAnalyzers={sampleAnalyzers}
+        initialActiveFilters={['Pod']}
+        onSave={onSaveSpy}
+      />,
+      {
+        stdout: mockStdout as any,
+        stdin: mockStdin as any,
+        interactive: true,
+      },
+    );
+
+    await waitForFrameToContain({ mockStdout, substring: 'Active: 1 / 12' });
+
+    // Move cursor down to Deployment (index 1, inactive)
+    mockStdin.sendKey({ name: 'down' });
+    await sleep(50);
+
+    // Press SPACE to toggle Deployment on
+    mockStdin.sendChar({ char: ' ' });
+    await waitForFrameToContain({ mockStdout, substring: 'Active: 2 / 12' });
+    await waitForFrameToContain({ mockStdout, substring: '[x] Deployment' });
+
+    expect(onSaveSpy).toHaveBeenCalledWith(['Pod', 'Deployment']);
+  });
+
+  it('exits cleanly on Q key', async () => {
+    const app = render(
+      <FiltersDashboard
+        availableAnalyzers={sampleAnalyzers}
+        initialActiveFilters={DEFAULT_FILTERS}
+      />,
+      {
+        stdout: mockStdout as any,
+        stdin: mockStdin as any,
+        interactive: true,
+      },
+    );
+
+    await waitForFrameToContain({ mockStdout, substring: 'Analyzer Filters' });
+
+    let exited = false;
+    app.waitUntilExit().then(() => {
+      exited = true;
+    });
+
+    mockStdin.sendChar({ char: 'q' });
+    await sleep(100);
+
+    expect(exited).toBe(true);
+  });
+});

--- a/src/__tests__/filters.test.ts
+++ b/src/__tests__/filters.test.ts
@@ -109,4 +109,22 @@ describe('filters command', () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown filter name'));
     expect(process.exitCode).toBe(1);
   });
+
+  it('exits with error when launched without a TTY terminal', async () => {
+    const origStdoutTTY = process.stdout.isTTY;
+    const origStdinTTY = process.stdin.isTTY;
+    process.stdout.isTTY = false as any;
+    process.stdin.isTTY = false as any;
+
+    try {
+      await program.parseAsync(['node', 'test', 'filters']);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Interactive filters dashboard requires a TTY terminal.'),
+      );
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.stdout.isTTY = origStdoutTTY;
+      process.stdin.isTTY = origStdinTTY;
+    }
+  });
 });

--- a/src/commands/filters.ts
+++ b/src/commands/filters.ts
@@ -2,8 +2,9 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { getActiveFilters, setActiveFilters } from '../config/store';
 import { registry } from '../analyzers';
+import { DEFAULT_FILTERS } from '../ui/FiltersDashboard';
 
-const DEFAULT_FILTERS = ['Pod', 'Deployment', 'Service', 'PersistentVolumeClaim', 'Node'];
+export { DEFAULT_FILTERS };
 
 /**
  * Lists the configured active filters and the available inactive ones.
@@ -109,7 +110,20 @@ export const registerFiltersCommand = (program: Command): void => {
   const filters = program
     .command('filters')
     .alias('filter')
-    .description('Manage active analyzers filters for kdm analyze');
+    .description('Manage active analyzers filters for kdm analyze')
+    .action(async () => {
+      if (!process.stdout.isTTY || !process.stdin.isTTY) {
+        console.error('Interactive filters dashboard requires a TTY terminal.');
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write('\x1Bc');
+      const { default: React } = await import('react');
+      const { render } = await import('ink');
+      const { FiltersDashboard } = await import('../ui/FiltersDashboard');
+      const app = render(React.createElement(FiltersDashboard));
+      await app.waitUntilExit();
+    });
 
   filters
     .command('list')

--- a/src/commands/filters.ts
+++ b/src/commands/filters.ts
@@ -1,8 +1,10 @@
+import React from 'react';
+import { render } from 'ink';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { getActiveFilters, setActiveFilters } from '../config/store';
 import { registry } from '../analyzers';
-import { DEFAULT_FILTERS } from '../ui/FiltersDashboard';
+import { FiltersDashboard, DEFAULT_FILTERS } from '../ui/FiltersDashboard';
 
 export { DEFAULT_FILTERS };
 
@@ -111,18 +113,14 @@ export const registerFiltersCommand = (program: Command): void => {
     .command('filters')
     .alias('filter')
     .description('Manage active analyzers filters for kdm analyze')
-    .action(async () => {
+    .action(() => {
       if (!process.stdout.isTTY || !process.stdin.isTTY) {
         console.error('Interactive filters dashboard requires a TTY terminal.');
         process.exitCode = 1;
         return;
       }
       process.stdout.write('\x1Bc');
-      const { default: React } = await import('react');
-      const { render } = await import('ink');
-      const { FiltersDashboard } = await import('../ui/FiltersDashboard');
-      const app = render(React.createElement(FiltersDashboard));
-      await app.waitUntilExit();
+      render(React.createElement(FiltersDashboard));
     });
 
   filters

--- a/src/ui/Checkbox.tsx
+++ b/src/ui/Checkbox.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Box, Text } from 'ink';
+import chalk from 'chalk';
+
+export interface CheckboxProps {
+  label: string;
+  checked?: boolean;
+  defaultChecked?: boolean;
+  isSelected?: boolean;
+  onChange?: (checked: boolean) => void;
+}
+
+/**
+ * Custom Ink Checkbox component rendering [x] / [ ] with cursor indicator and chalk colors.
+ */
+export const Checkbox: React.FC<CheckboxProps> = ({
+  label,
+  checked,
+  defaultChecked = false,
+  isSelected = false,
+  onChange,
+}) => {
+  const [internalChecked, setInternalChecked] = useState(defaultChecked);
+  const isChecked = checked !== undefined ? checked : internalChecked;
+
+  const cursor = isSelected ? chalk.cyan('> ') : '  ';
+  const box = isChecked ? chalk.green('[x]') : chalk.gray('[ ]');
+  const text = isSelected ? chalk.bold.cyan(label) : label;
+
+  return (
+    <Box flexDirection="row">
+      <Text>
+        {cursor}
+        {box} {text}
+      </Text>
+    </Box>
+  );
+};

--- a/src/ui/FiltersDashboard.tsx
+++ b/src/ui/FiltersDashboard.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useMemo } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+import { registry } from '../analyzers';
+import { getActiveFilters, rawConfigStore, setActiveFilters } from '../config/store';
+import { Checkbox } from './Checkbox';
+
+export const DEFAULT_FILTERS = ['Pod', 'Deployment', 'Service', 'PersistentVolumeClaim', 'Node'];
+
+export interface FiltersDashboardProps {
+  availableAnalyzers?: string[];
+  initialActiveFilters?: string[];
+  onSave?: (filters: string[]) => void;
+}
+
+/**
+ * Resolves the starting active filters based on store configuration or defaults.
+ */
+const resolveInitialActiveFilters = (provided?: string[]): string[] => {
+  if (provided !== undefined) {
+    return provided;
+  }
+  const configured = getActiveFilters();
+  if (configured.length > 0) {
+    return configured;
+  }
+  try {
+    if (rawConfigStore.has('activeFilters')) {
+      return configured;
+    }
+  } catch {
+    // Falls back to defaults in test or non-Conf environments
+  }
+  return DEFAULT_FILTERS;
+};
+
+export const FiltersDashboard: React.FC<FiltersDashboardProps> = ({
+  availableAnalyzers,
+  initialActiveFilters,
+  onSave = setActiveFilters,
+}) => {
+  const { exit } = useApp();
+
+  const analyzers = useMemo(() => {
+    return availableAnalyzers ?? registry.list().map((a) => a.name);
+  }, [availableAnalyzers]);
+
+  const [activeFilters, setActiveFiltersState] = useState<string[]>(() =>
+    resolveInitialActiveFilters(initialActiveFilters),
+  );
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useInput((input, key) => {
+    if (key.upArrow || input === 'k') {
+      setSelectedIndex((prev) => Math.max(0, prev - 1));
+      return;
+    }
+
+    if (key.downArrow || input === 'j') {
+      setSelectedIndex((prev) => (analyzers.length > 0 ? Math.min(analyzers.length - 1, prev + 1) : 0));
+      return;
+    }
+
+    if (input === ' ') {
+      const current = analyzers[selectedIndex];
+      if (!current) return;
+
+      setActiveFiltersState((prev) => {
+        const next = prev.includes(current)
+          ? prev.filter((f) => f !== current)
+          : [...prev, current];
+        onSave?.(next);
+        return next;
+      });
+      return;
+    }
+
+    if (input === 'q' || input === 'Q' || key.escape) {
+      exit();
+    }
+  });
+
+  const divider = '─'.repeat(54);
+
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={0}>
+      <Box flexDirection="row" justifyContent="space-between" width={54}>
+        <Text bold color="cyan">
+          Analyzer Filters
+        </Text>
+        <Text bold color="green">
+          {`Active: ${activeFilters.length} / ${analyzers.length}`}
+        </Text>
+      </Box>
+
+      <Text dimColor>{divider}</Text>
+
+      <Box flexDirection="column">
+        {analyzers.length === 0 ? (
+          <Text dimColor>(no analyzers available)</Text>
+        ) : (
+          analyzers.map((name, index) => (
+            <Checkbox
+              key={name}
+              label={name}
+              checked={activeFilters.includes(name)}
+              isSelected={index === selectedIndex}
+            />
+          ))
+        )}
+      </Box>
+
+      <Text dimColor>{divider}</Text>
+
+      <Box flexDirection="row">
+        <Text color="cyan" bold>
+          SPACE
+        </Text>
+        <Text dimColor>:Toggle </Text>
+        <Text color="cyan" bold>
+          ↑↓
+        </Text>
+        <Text dimColor>:Navigate </Text>
+        <Text color="cyan" bold>
+          Q
+        </Text>
+        <Text dimColor>:Quit </Text>
+        <Text dimColor>(changes auto-saved)</Text>
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
Closes #142

- Convert 'kdm filters' into an interactive multi-select checklist
- Support keyboard navigation with ↑/↓, Space to toggle, and Q to quit
- Real-time active counter header and instant auto-saving to config store
- Custom Ink Checkbox component with [x] / [ ] indicators and chalk styling
- Retain existing 'list', 'add', and 'remove' subcommands for backward compatibility
- Add comprehensive test coverage in filters-dashboard.test.tsx and filters.test.ts