### PR TITLE
fix(ci): use built-in token for publish checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
 
       - name: Setup Node.cjs


### PR DESCRIPTION
## Summary
- use the Actions-provided token for checkout instead of the unusable `GH_PAT` secret
- retain full history and existing `contents: write` permission for release commits and tags

## Validation
- Parsed `.github/workflows/publish.yml` and verified checkout configuration and release permissions

Fixes the publish workflow checkout failure that prevented `package.json` from being available.