### PR TITLE
fix(ci): restore protected release token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          # Required to bypass the protected-main release ruleset when pushing the version commit.
+          token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
 
       - name: Setup Node.cjs


### PR DESCRIPTION
## Summary
- use `GH_PAT` for the publish checkout so the release version commit can bypass the protected-main ruleset
- retain full-history checkout and existing release permissions

## Required configuration
Rotate the `GH_PAT` repository secret with a current token from an account authorized to bypass the `main` ruleset before dispatching Publish.

## Validation
- parsed `.github/workflows/publish.yml` and verified the checkout token, fetch depth, and write permission.