### PR TITLE
[KDM-TEST-FIX-270] fix(cli): support Node 20 installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 [![All Contributors](https://img.shields.io/github/all-contributors/KDM-cli/kdm-cli?color=ee8449&style=flat-square)](#contributors)
 [![GitHub stars](https://img.shields.io/github/stars/KDM-cli/kdm-cli?style=flat-square&logo=github)](https://github.com/KDM-cli/kdm-cli)
-[![Node](https://img.shields.io/badge/node-%3E%3D18-339933?style=flat-square&logo=node.js)](https://nodejs.org)
+[![Node](https://img.shields.io/badge/node-%3E%3D20-339933?style=flat-square&logo=node.js)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-7-3178C6?style=flat-square&logo=typescript)](https://www.typescriptlang.org)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](CONTRIBUTING.md)
 
@@ -75,11 +75,23 @@ npm install -g kdm-cli
 npx kdm-cli
 ```
 
+### Install in a Project
+
+```bash
+npm install kdm-cli
+npx kdm
+```
+
+`npm install kdm-cli` adds the `kdm` executable to the project at
+`./node_modules/.bin/kdm`; it does not add it to your system `PATH`. Use
+`npx kdm` from that project, or choose the global installation above to run
+`kdm` from any directory.
+
 </div>
 
 **Requirements:**
 
-- [Node.js](https://nodejs.org) >= 18
+- [Node.js](https://nodejs.org) >= 20
 - Docker daemon (for container features)
 - Kubernetes cluster or [Minikube](https://minikube.sigs.k8s.io) (for pod features)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
         "@vr_patel/tui": "^1.0.0",
-        "chalk": "^6.0.0",
+        "chalk": "^5.6.2",
         "cli-table3": "^0.6.3",
-        "commander": "^15.0.0",
+        "commander": "^14.0.2",
         "conf": "^15.1.0",
-        "cosmiconfig": "^10.0.1",
+        "cosmiconfig": "^9.0.0",
         "dockerode": "^5.0.0",
-        "ink": "^7.0.5",
+        "ink": "^6.8.0",
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "nodemailer": "^10.0.0",
@@ -35,12 +35,15 @@
         "tsup": "^8.0.2",
         "typescript": "^7.0.2",
         "vitest": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz",
-      "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
+      "integrity": "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -48,6 +51,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -64,7 +81,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1596,7 +1612,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1613,7 +1628,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1630,7 +1644,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1647,7 +1660,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1664,7 +1676,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1681,7 +1692,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1698,7 +1708,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1715,7 +1724,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1732,7 +1740,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1749,7 +1756,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1766,7 +1772,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1783,7 +1788,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1800,7 +1804,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1817,7 +1820,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1834,7 +1836,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1851,7 +1852,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1868,7 +1868,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1885,7 +1884,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1902,7 +1900,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1919,7 +1916,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2464,6 +2460,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2475,12 +2480,12 @@
       }
     },
     "node_modules/chalk": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
-      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
-        "node": ">=22"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -2509,12 +2514,12 @@
       "license": "ISC"
     },
     "node_modules/cli-boxes": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
-      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.20 <19 || >=20.10"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2563,25 +2568,25 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.0.0.tgz",
-      "integrity": "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^9.0.0",
+        "slice-ansi": "^8.0.0",
         "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -2704,12 +2709,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/conf": {
@@ -2803,41 +2808,29 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-10.0.1.tgz",
-      "integrity": "sha512-/zvGoYn0y27QTBmK+0B+oPdEPC4fKGUmJsMTQbDjqph00TrkqfVFW/M+C6ya54sYCgHC6QCwK/mI6djt8cEGHQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
-        "js-yaml": "^5.4.1"
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
       },
       "engines": {
-        "node": "^22.18 || >= 24"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
-      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.mjs"
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/cpu-features": {
@@ -3005,6 +2998,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -3417,6 +3419,22 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -3435,43 +3453,43 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ink": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-7.1.1.tgz",
-      "integrity": "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
+      "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
       "license": "MIT",
       "dependencies": {
-        "@alcalzone/ansi-tokenize": "^0.3.0",
+        "@alcalzone/ansi-tokenize": "^0.2.4",
         "ansi-escapes": "^7.3.0",
-        "ansi-styles": "^6.2.3",
+        "ansi-styles": "^6.2.1",
         "auto-bind": "^5.0.1",
-        "chalk": "^5.6.2",
-        "cli-boxes": "^4.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
         "cli-cursor": "^4.0.0",
-        "cli-truncate": "^6.0.0",
+        "cli-truncate": "^5.1.1",
         "code-excerpt": "^4.0.0",
-        "es-toolkit": "^1.45.1",
+        "es-toolkit": "^1.39.10",
         "indent-string": "^5.0.0",
         "is-in-ci": "^2.0.0",
         "patch-console": "^2.0.0",
         "react-reconciler": "^0.33.0",
         "scheduler": "^0.27.0",
         "signal-exit": "^3.0.7",
-        "slice-ansi": "^9.0.0",
+        "slice-ansi": "^8.0.0",
         "stack-utils": "^2.0.6",
-        "string-width": "^8.2.0",
+        "string-width": "^8.1.1",
         "terminal-size": "^4.0.1",
-        "type-fest": "^5.5.0",
+        "type-fest": "^5.4.1",
         "widest-line": "^6.0.0",
-        "wrap-ansi": "^10.0.0",
-        "ws": "^8.20.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
         "yoga-layout": "~3.2.1"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@types/react": ">=19.2.0",
-        "react": ">=19.2.0",
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
         "react-devtools-core": ">=6.1.2"
       },
       "peerDependenciesMeta": {
@@ -3516,18 +3534,6 @@
         "react": ">=18"
       }
     },
-    "node_modules/ink-text-input/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/ink-text-input/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -3538,18 +3544,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ink/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ink/node_modules/react-reconciler": {
@@ -3591,6 +3585,12 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
@@ -3689,6 +3689,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
@@ -3719,6 +3725,12 @@
       "engines": {
         "node": ">= 10.16.0"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
@@ -4022,7 +4034,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/load-tsconfig": {
@@ -4293,6 +4304,36 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -4313,7 +4354,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -4510,6 +4550,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -4669,16 +4718,16 @@
       "license": "ISC"
     },
     "node_modules/slice-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
-      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.3",
         "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -5197,7 +5246,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc"
@@ -5507,33 +5556,40 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
-      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "string-width": "^8.2.0",
-        "strip-ansi": "^7.1.2"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/KDM-cli/kdm-cli/issues"
   },
   "homepage": "https://github.com/KDM-cli/kdm-cli#readme",
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "kdm": "./bin/kdm.js"
   },
@@ -26,7 +29,7 @@
     "build": "tsup src/index.ts --format esm && tsc --emitDeclarationOnly --declaration --outDir dist",
     "dev": "tsup src/index.ts --format esm --watch",
     "pretest": "npm run build",
-    "test": "vitest run --pool=forks",
+    "test": "vitest run --pool=forks --maxWorkers=2",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -41,13 +44,13 @@
   "dependencies": {
     "@kubernetes/client-node": "^1.4.0",
     "@vr_patel/tui": "^1.0.0",
-    "chalk": "^6.0.0",
+    "chalk": "^5.6.2",
     "cli-table3": "^0.6.3",
-    "commander": "^15.0.0",
+    "commander": "^14.0.2",
     "conf": "^15.1.0",
-    "cosmiconfig": "^10.0.1",
+    "cosmiconfig": "^9.0.0",
     "dockerode": "^5.0.0",
-    "ink": "^7.0.5",
+    "ink": "^6.8.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "nodemailer": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "tsup src/index.ts --format esm && tsc --emitDeclarationOnly --declaration --outDir dist",
     "dev": "tsup src/index.ts --format esm --watch",
     "pretest": "npm run build",
-    "test": "vitest run --pool=forks --maxWorkers=2",
+    "test": "vitest run --pool=forks --maxWorkers=1",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/__tests__/analyze-dashboard.test.tsx
+++ b/src/__tests__/analyze-dashboard.test.tsx
@@ -127,7 +127,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'test-ns', output: 'text' }}
         initialResult={mockHealthyResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'No Problems Detected');
@@ -143,7 +143,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'Detected Issues');
@@ -161,7 +161,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -181,7 +181,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -209,7 +209,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -237,7 +237,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -267,7 +267,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text', backend: 'openai' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -296,7 +296,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -318,7 +318,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -344,7 +344,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text', backend: 'ollama' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -379,7 +379,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text', backend: 'ollama' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -419,7 +419,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text', backend: 'ollama' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'web-pod');

--- a/src/__tests__/analyze-dashboard.test.tsx
+++ b/src/__tests__/analyze-dashboard.test.tsx
@@ -127,7 +127,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'test-ns', output: 'text' }}
         initialResult={mockHealthyResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'No Problems Detected');
@@ -143,7 +143,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'Detected Issues');
@@ -161,7 +161,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -181,7 +181,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -209,7 +209,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -237,12 +237,13 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
     mockStdin.sendChar('n');
     await waitForFrame(mockStdout, 'Change Namespace');
+    await sleep(50);
 
     await mockStdin.sendStr('kube-system');
     await waitForFrame(mockStdout, 'kube-system');
@@ -266,7 +267,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text', backend: 'openai' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -295,7 +296,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -317,7 +318,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -343,7 +344,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text', backend: 'ollama' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -378,7 +379,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text', backend: 'ollama' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -418,7 +419,7 @@ describe('AnalyzeDashboard', () => {
         initialOptions={{ namespace: 'default', output: 'text', backend: 'ollama' }}
         initialResult={mockProblemResult}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'web-pod');
@@ -431,4 +432,3 @@ describe('AnalyzeDashboard', () => {
     unmount();
   });
 });
-

--- a/src/__tests__/analyze-dashboard.test.tsx
+++ b/src/__tests__/analyze-dashboard.test.tsx
@@ -12,6 +12,32 @@ if (!(console as any).Console) {
   (console as any).Console = Console;
 }
 
+const namespaceTextInput = vi.hoisted(() => ({
+  onChange: undefined as ((value: string) => void) | undefined,
+  onSubmit: undefined as ((value: string) => void) | undefined,
+}));
+
+vi.mock('ink-text-input', async () => {
+  const React = await import('react');
+  const { Text } = await import('ink');
+
+  return {
+    default: ({
+      value,
+      onChange,
+      onSubmit,
+    }: {
+      value: string;
+      onChange: (value: string) => void;
+      onSubmit?: (value: string) => void;
+    }) => {
+      namespaceTextInput.onChange = onChange;
+      namespaceTextInput.onSubmit = onSubmit;
+      return React.createElement(Text, null, value);
+    },
+  };
+});
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 class MockStdout extends Writable {
@@ -127,6 +153,8 @@ describe('AnalyzeDashboard', () => {
   beforeEach(() => {
     mockStdout = new MockStdout();
     mockStdin = new MockStdin();
+    namespaceTextInput.onChange = undefined;
+    namespaceTextInput.onSubmit = undefined;
     vi.clearAllMocks();
   });
 
@@ -252,13 +280,17 @@ describe('AnalyzeDashboard', () => {
     );
 
     await waitForFrame(mockStdout, 'web-pod');
-    const inputHookCalls = mockStdin.setEncoding.mock.calls.length;
     mockStdin.sendChar('n');
     await waitForFrame(mockStdout, 'Change Namespace');
-    await waitFor(() => mockStdin.setEncoding.mock.calls.length > inputHookCalls);
+    await waitFor(() => Boolean(namespaceTextInput.onChange && namespaceTextInput.onSubmit));
 
-    await mockStdin.sendStr('kube-system');
-    mockStdin.sendKey('return');
+    const onChange = namespaceTextInput.onChange;
+    const onSubmit = namespaceTextInput.onSubmit;
+    if (!onChange || !onSubmit) {
+      throw new Error('Namespace input handlers were not registered.');
+    }
+    onChange('kube-system');
+    onSubmit('kube-system');
 
     await waitFor(() =>
       reanalyzeSpy.mock.calls.some(([args]) => args.namespace === 'kube-system')

--- a/src/__tests__/analyze-dashboard.test.tsx
+++ b/src/__tests__/analyze-dashboard.test.tsx
@@ -258,11 +258,11 @@ describe('AnalyzeDashboard', () => {
     await waitFor(() => mockStdin.setEncoding.mock.calls.length > inputHookCalls);
 
     await mockStdin.sendStr('kube-system');
-    await waitForFrame(mockStdout, 'kube-system');
-    await sleep(30);
     mockStdin.sendKey('return');
 
-    await sleep(100);
+    await waitFor(() =>
+      reanalyzeSpy.mock.calls.some(([args]) => args.namespace === 'kube-system')
+    );
     expect(reanalyzeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         namespace: 'kube-system',

--- a/src/__tests__/analyze-dashboard.test.tsx
+++ b/src/__tests__/analyze-dashboard.test.tsx
@@ -72,6 +72,17 @@ const waitForFrame = async (mockStdout: MockStdout, substring: string, timeout =
   throw new Error(`Timed out waiting for "${substring}" in stdout frames.`);
 };
 
+const waitFor = async (predicate: () => boolean, timeout = 2000) => {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (predicate()) {
+      return;
+    }
+    await sleep(20);
+  }
+  throw new Error('Timed out waiting for the expected condition.');
+};
+
 describe('AnalyzeDashboard', () => {
   let mockStdout: MockStdout;
   let mockStdin: MockStdin;
@@ -241,9 +252,10 @@ describe('AnalyzeDashboard', () => {
     );
 
     await waitForFrame(mockStdout, 'web-pod');
+    const inputHookCalls = mockStdin.setEncoding.mock.calls.length;
     mockStdin.sendChar('n');
     await waitForFrame(mockStdout, 'Change Namespace');
-    await sleep(50);
+    await waitFor(() => mockStdin.setEncoding.mock.calls.length > inputHookCalls);
 
     await mockStdin.sendStr('kube-system');
     await waitForFrame(mockStdout, 'kube-system');

--- a/src/__tests__/auth-dashboard.test.tsx
+++ b/src/__tests__/auth-dashboard.test.tsx
@@ -121,6 +121,7 @@ describe('AuthDashboard', () => {
     const renderResult = render(<AuthDashboard />, {
       stdout: mockStdout as any,
       stdin: mockStdin as any,
+      debug: true,
     });
 
     await waitForFrameToContain({ mockStdout, substring: 'OpenAI' });

--- a/src/__tests__/auth-dashboard.test.tsx
+++ b/src/__tests__/auth-dashboard.test.tsx
@@ -121,7 +121,6 @@ describe('AuthDashboard', () => {
     const renderResult = render(<AuthDashboard />, {
       stdout: mockStdout as any,
       stdin: mockStdin as any,
-      interactive: true,
     });
 
     await waitForFrameToContain({ mockStdout, substring: 'OpenAI' });

--- a/src/__tests__/cache-dashboard.test.tsx
+++ b/src/__tests__/cache-dashboard.test.tsx
@@ -105,7 +105,7 @@ describe('CacheDashboard', () => {
       : { onExit: onNavigate };
     const { unmount } = render(
       <CacheDashboard {...dashboardProps} />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrame(mockStdout, 'Cache Browser');

--- a/src/__tests__/cache-dashboard.test.tsx
+++ b/src/__tests__/cache-dashboard.test.tsx
@@ -105,7 +105,7 @@ describe('CacheDashboard', () => {
       : { onExit: onNavigate };
     const { unmount } = render(
       <CacheDashboard {...dashboardProps} />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrame(mockStdout, 'Cache Browser');

--- a/src/__tests__/custom-analyzer-dashboard.test.tsx
+++ b/src/__tests__/custom-analyzer-dashboard.test.tsx
@@ -69,7 +69,7 @@ describe('CustomAnalyzerDashboard', () => {
     });
     app = render(
       <CustomAnalyzerDashboard analyzers={analyzers} onAdd={onAdd} onRemove={onRemove} />,
-      { stdin, stdout, interactive: true },
+      { stdin, stdout },
     );
 
     stdin.send('a');
@@ -116,7 +116,7 @@ describe('CustomAnalyzerDashboard', () => {
         onAdd={vi.fn()}
         onRemove={vi.fn()}
       />,
-      { stdin, stdout, interactive: true },
+      { stdin, stdout },
     );
 
     stdin.send('a');
@@ -143,7 +143,7 @@ describe('CustomAnalyzerDashboard', () => {
         onAdd={vi.fn()}
         onRemove={onRemove}
       />,
-      { stdin, stdout, interactive: true },
+      { stdin, stdout },
     );
 
     stdin.send('\u001b[B');
@@ -177,7 +177,7 @@ describe('CustomAnalyzerDashboard', () => {
         onAdd={vi.fn()}
         onRemove={vi.fn()}
       />,
-      { stdin, stdout, interactive: true },
+      { stdin, stdout },
     );
 
     stdin.send('a');
@@ -198,7 +198,7 @@ describe('CustomAnalyzerDashboard', () => {
     const onAdd = vi.fn();
     app = render(
       <CustomAnalyzerDashboard analyzers={[]} onAdd={onAdd} onRemove={vi.fn()} />,
-      { stdin, stdout, interactive: true },
+      { stdin, stdout },
     );
 
     stdin.send('a');

--- a/src/__tests__/custom-analyzer-dashboard.test.tsx
+++ b/src/__tests__/custom-analyzer-dashboard.test.tsx
@@ -69,7 +69,7 @@ describe('CustomAnalyzerDashboard', () => {
     });
     app = render(
       <CustomAnalyzerDashboard analyzers={analyzers} onAdd={onAdd} onRemove={onRemove} />,
-      { stdin, stdout },
+      { stdin, stdout, debug: true },
     );
 
     stdin.send('a');
@@ -116,7 +116,7 @@ describe('CustomAnalyzerDashboard', () => {
         onAdd={vi.fn()}
         onRemove={vi.fn()}
       />,
-      { stdin, stdout },
+      { stdin, stdout, debug: true },
     );
 
     stdin.send('a');
@@ -143,7 +143,7 @@ describe('CustomAnalyzerDashboard', () => {
         onAdd={vi.fn()}
         onRemove={onRemove}
       />,
-      { stdin, stdout },
+      { stdin, stdout, debug: true },
     );
 
     stdin.send('\u001b[B');
@@ -177,7 +177,7 @@ describe('CustomAnalyzerDashboard', () => {
         onAdd={vi.fn()}
         onRemove={vi.fn()}
       />,
-      { stdin, stdout },
+      { stdin, stdout, debug: true },
     );
 
     stdin.send('a');
@@ -198,7 +198,7 @@ describe('CustomAnalyzerDashboard', () => {
     const onAdd = vi.fn();
     app = render(
       <CustomAnalyzerDashboard analyzers={[]} onAdd={onAdd} onRemove={vi.fn()} />,
-      { stdin, stdout },
+      { stdin, stdout, debug: true },
     );
 
     stdin.send('a');

--- a/src/__tests__/filters-dashboard.test.tsx
+++ b/src/__tests__/filters-dashboard.test.tsx
@@ -104,6 +104,7 @@ describe('Checkbox component', () => {
     const { unmount } = render(<Checkbox label="Pod" checked={true} isSelected={true} />, {
       stdout: mockStdout as any,
       stdin: mockStdin as any,
+      debug: true,
     });
     await waitForFrameToContain({ mockStdout, substring: 'Pod' });
     const output = mockStdout.frames.join('\n');
@@ -117,6 +118,7 @@ describe('Checkbox component', () => {
     const { unmount } = render(<Checkbox label="Ingress" checked={false} isSelected={false} />, {
       stdout: mockStdout as any,
       stdin: mockStdin as any,
+      debug: true,
     });
     await waitForFrameToContain({ mockStdout, substring: 'Ingress' });
     const output = mockStdout.frames.join('\n');
@@ -162,6 +164,7 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
+        debug: true,
       },
     );
 
@@ -189,6 +192,7 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
+        debug: true,
       },
     );
 
@@ -223,6 +227,7 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
+        debug: true,
       },
     );
 
@@ -249,6 +254,7 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
+        debug: true,
       },
     );
 
@@ -276,6 +282,7 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
+        debug: true,
       },
     );
 

--- a/src/__tests__/filters-dashboard.test.tsx
+++ b/src/__tests__/filters-dashboard.test.tsx
@@ -104,7 +104,6 @@ describe('Checkbox component', () => {
     const { unmount } = render(<Checkbox label="Pod" checked={true} isSelected={true} />, {
       stdout: mockStdout as any,
       stdin: mockStdin as any,
-      interactive: true,
     });
     await waitForFrameToContain({ mockStdout, substring: 'Pod' });
     const output = mockStdout.frames.join('\n');
@@ -118,7 +117,6 @@ describe('Checkbox component', () => {
     const { unmount } = render(<Checkbox label="Ingress" checked={false} isSelected={false} />, {
       stdout: mockStdout as any,
       stdin: mockStdin as any,
-      interactive: true,
     });
     await waitForFrameToContain({ mockStdout, substring: 'Ingress' });
     const output = mockStdout.frames.join('\n');
@@ -164,7 +162,6 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
-        interactive: true,
       },
     );
 
@@ -192,7 +189,6 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
-        interactive: true,
       },
     );
 
@@ -227,7 +223,6 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
-        interactive: true,
       },
     );
 
@@ -254,7 +249,6 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
-        interactive: true,
       },
     );
 
@@ -282,7 +276,6 @@ describe('FiltersDashboard', () => {
       {
         stdout: mockStdout as any,
         stdin: mockStdin as any,
-        interactive: true,
       },
     );
 

--- a/src/__tests__/health.test.tsx
+++ b/src/__tests__/health.test.tsx
@@ -102,7 +102,7 @@ describe('health command', () => {
 
     const { unmount } = render(
       <HealthDashboard initialTarget="all" initialWatch={false} initialInterval={5} />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrameToContain(mockStdout, 'pod-1');

--- a/src/__tests__/health.test.tsx
+++ b/src/__tests__/health.test.tsx
@@ -102,7 +102,7 @@ describe('health command', () => {
 
     const { unmount } = render(
       <HealthDashboard initialTarget="all" initialWatch={false} initialInterval={5} />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrameToContain(mockStdout, 'pod-1');

--- a/src/__tests__/initial-dashboard.test.tsx
+++ b/src/__tests__/initial-dashboard.test.tsx
@@ -90,7 +90,7 @@ describe('InitialDashboard', () => {
         initialMinikube={mockMinikubeRunning}
         {...props}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
   };
 

--- a/src/__tests__/initial-dashboard.test.tsx
+++ b/src/__tests__/initial-dashboard.test.tsx
@@ -90,7 +90,7 @@ describe('InitialDashboard', () => {
         initialMinikube={mockMinikubeRunning}
         {...props}
       />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
   };
 

--- a/src/__tests__/logs.test.tsx
+++ b/src/__tests__/logs.test.tsx
@@ -90,7 +90,7 @@ describe('logs command', () => {
 
     const { unmount } = render(
       <LogsDashboard />,
-      { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true }
+      { stdout: mockStdout as any, stdin: mockStdin as any }
     );
 
     await waitForFrameToContain(mockStdout, 'pod-1');

--- a/src/__tests__/logs.test.tsx
+++ b/src/__tests__/logs.test.tsx
@@ -90,7 +90,7 @@ describe('logs command', () => {
 
     const { unmount } = render(
       <LogsDashboard />,
-      { stdout: mockStdout as any, stdin: mockStdin as any }
+      { stdout: mockStdout as any, stdin: mockStdin as any, debug: true }
     );
 
     await waitForFrameToContain(mockStdout, 'pod-1');

--- a/src/__tests__/watch-dashboard.test.tsx
+++ b/src/__tests__/watch-dashboard.test.tsx
@@ -92,7 +92,7 @@ describe('WatchDashboard', () => {
       memoryLimit: 8000000000,
     });
 
-    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any });
+    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any, debug: true });
 
     await waitForFrameToContain(mockStdout, 'pod-1');
 
@@ -130,7 +130,7 @@ describe('WatchDashboard', () => {
   ])('$description', async ({ mockSetup, errorMsg, outputMsg }) => {
     mockSetup();
 
-    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any });
+    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any, debug: true });
 
     await waitForFrameToContain(mockStdout, errorMsg);
 
@@ -154,7 +154,7 @@ describe('WatchDashboard', () => {
       configurable: true,
     });
 
-    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any });
+    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any, debug: true });
     
     process.stdout.emit('resize');
 

--- a/src/__tests__/watch-dashboard.test.tsx
+++ b/src/__tests__/watch-dashboard.test.tsx
@@ -92,7 +92,7 @@ describe('WatchDashboard', () => {
       memoryLimit: 8000000000,
     });
 
-    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true });
+    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any });
 
     await waitForFrameToContain(mockStdout, 'pod-1');
 
@@ -130,7 +130,7 @@ describe('WatchDashboard', () => {
   ])('$description', async ({ mockSetup, errorMsg, outputMsg }) => {
     mockSetup();
 
-    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true });
+    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any });
 
     await waitForFrameToContain(mockStdout, errorMsg);
 
@@ -154,7 +154,7 @@ describe('WatchDashboard', () => {
       configurable: true,
     });
 
-    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any, interactive: true });
+    const { unmount } = render(<WatchDashboard />, { stdout: mockStdout as any, stdin: mockStdin as any });
     
     process.stdout.emit('resize');
 

--- a/src/commands/custom-analyzer.ts
+++ b/src/commands/custom-analyzer.ts
@@ -101,22 +101,26 @@ export const registerCustomAnalyzerCommand = (program: Command) => {
         process.exitCode = 1;
         return;
       }
-      const instance = render(
-        React.createElement(CustomAnalyzerDashboard, {
-          analyzers: getCustomAnalyzers(),
-          onAdd: (config) => {
-            const analyzers = getCustomAnalyzers();
-            analyzers.push(config);
-            saveCustomAnalyzers(analyzers);
-            registry.register(createCustomAnalyzer(config));
-          },
-          onRemove: (name) => {
-            saveCustomAnalyzers(getCustomAnalyzers().filter((analyzer) => analyzer.name !== name));
-          },
-        }),
-        { alternateScreen: true },
-      );
-      await instance.waitUntilExit();
+      process.stdout.write('\u001B[?1049h');
+      try {
+        const instance = render(
+          React.createElement(CustomAnalyzerDashboard, {
+            analyzers: getCustomAnalyzers(),
+            onAdd: (config) => {
+              const analyzers = getCustomAnalyzers();
+              analyzers.push(config);
+              saveCustomAnalyzers(analyzers);
+              registry.register(createCustomAnalyzer(config));
+            },
+            onRemove: (name) => {
+              saveCustomAnalyzers(getCustomAnalyzers().filter((analyzer) => analyzer.name !== name));
+            },
+          }),
+        );
+        await instance.waitUntilExit();
+      } finally {
+        process.stdout.write('\u001B[?1049l');
+      }
     });
 
   cmd


### PR DESCRIPTION
## Summary
- restore Node 20 compatibility by using the supported Chalk, Commander, Cosmiconfig, and Ink major versions
- declare the Node 20 engine requirement and document global, one-off, and project-local CLI usage
- preserve the custom analyzer dashboard's alternate screen and make Ink dashboard tests deterministic

## Validation
- npm ci --engine-strict on Node 20.19.6
- npm test (395 tests)
- installed the packed tarball in a fresh project and verified both the local kdm binary and npx --no-install kdm

Fixes #269