### PR TITLE
[KDM-CLI-FIX-299] Fix malformed URL handling and custom headers in AzureOpenAIClient

### DIFF
--- a/src/ai/azure-openai.ts
+++ b/src/ai/azure-openai.ts
@@ -11,16 +11,21 @@ export class AzureOpenAIClient implements AIClient {
   private apiKey = '';
   private model = '';
   private temperature = 0.7;
+  private customHeaders: Record<string, string> = {};
 
   /**
    * Configures the Azure OpenAI client with deployment endpoint and credentials.
    * @param config The provider configuration.
    */
   async configure(config: AIProviderConfig): Promise<void> {
-    this.baseUrl = config.baseUrl ?? '';
-    this.apiKey = config.password ?? '';
+    if (!config.baseUrl || !config.password) {
+      throw new Error('Azure OpenAI baseUrl and password (api-key) are required.');
+    }
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.apiKey = config.password;
     this.model = config.model ?? 'gpt-4';
     this.temperature = config.temperature ?? 0.7;
+    this.customHeaders = config.customHeaders ?? {};
   }
 
   /**
@@ -32,7 +37,11 @@ export class AzureOpenAIClient implements AIClient {
     const url = `${this.baseUrl}/openai/deployments/${this.model}/chat/completions?api-version=2024-02-01`;
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'api-key': this.apiKey },
+      headers: {
+        'Content-Type': 'application/json',
+        'api-key': this.apiKey,
+        ...this.customHeaders
+      },
       body: JSON.stringify({
         messages: [{ role: 'user', content: prompt }],
         temperature: this.temperature,


### PR DESCRIPTION
This PR fixes issue #266 in `kdm-cli`. The PR is targeted at upstream main.

**Changes Made:**
1. **Double-Slash URL Error**: Normalized `this.baseUrl` by removing trailing slashes (`this.baseUrl.replace(/\/+$/, '')`).
2. **Missing Base URL Check**: Added validation in `configure()` to check if `baseUrl` and `apiKey` (`password`) are provided.
3. **Missing Custom Headers**: `customHeaders` configured in `AIProviderConfig` are now forwarded in the `fetch` request.

Tested changes with `npm run test` which passed successfully.