### PR TITLE
[KDM-TEST-FIX-305] Fix sensitive data leak and DoS vulnerability in HTTP server

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -11,9 +11,13 @@ vi.mock('../config/store', () => ({
   getConfig: vi.fn(() => ({
     ai: {
       providers: [
-        { name: 'openai', model: 'gpt-4', password: 'secret-password' },
+          { name: 'openai', model: 'gpt-4', password: 'secret-password', customHeaders: { 'Authorization': 'Bearer secret-token' } },
       ],
     },
+      notifications: {
+        discordWebhook: 'https://discord.com/api/webhooks/123/secret',
+        emailPassword: 'my-email-password'
+      }
   })),
 }));
 
@@ -56,12 +60,36 @@ describe('HTTP Server', () => {
     expect(Array.isArray(body.filters)).toBe(true);
   });
 
-  it('responds to GET /config with masked passwords', async () => {
+  it('responds to GET /config with masked secrets', async () => {
     serverInstance = await createServer({ port: 0 });
     const response = await fetch(`http://localhost:${serverInstance.port}/config`);
     expect(response.status).toBe(200);
     const body = await response.json() as any;
     expect(body.ai.providers[0].password).toBe('****');
+    expect(body.ai.providers[0].customHeaders['Authorization']).toBe('****');
+    expect(body.notifications.discordWebhook).toBe('****');
+    expect(body.notifications.emailPassword).toBe('****');
+  });
+
+  it('rejects POST /analyze body larger than 1MB', async () => {
+    serverInstance = await createServer({ port: 0 });
+    const largeBody = 'a'.repeat(1024 * 1024 + 10);
+    const response = await fetch(`http://localhost:${serverInstance.port}/analyze`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: largeBody,
+    });
+    expect(response.status).toBe(500);
+    const body = await response.json() as any;
+    expect(body.error).toBe('Payload Too Large');
+  });
+
+  it('strips query parameters when routing', async () => {
+    serverInstance = await createServer({ port: 0 });
+    const response = await fetch(`http://localhost:${serverInstance.port}/health?probe=1`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ status: 'ok' });
   });
 
   it('handles GET /config errors gracefully', async () => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -34,10 +34,26 @@ interface AnalyzeRequestBody {
  * @returns Parsed body string.
  */
 export const readBody = (req: any): Promise<string> =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     let body = '';
-    req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+    // Limit to 1MB to prevent DoS via memory exhaustion
+    const MAX_SIZE = 1024 * 1024;
+    let size = 0;
+
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_SIZE) {
+        reject(new Error('Payload Too Large'));
+        // Let the request complete its stream but ignore the rest,
+        // so we don't close the socket abruptly resulting in UND_ERR_SOCKET
+        req.pause();
+        return;
+      }
+      body += chunk.toString();
+    });
+
     req.on('end', () => resolve(body));
+    req.on('error', (err: Error) => reject(err));
   });
 
 /**
@@ -103,7 +119,16 @@ export const handleConfig = (res: any): void => {
       ...config,
       ai: config.ai ? {
         ...config.ai,
-        providers: config.ai.providers.map((p) => ({ ...p, password: '****' })),
+        providers: config.ai.providers.map((p) => ({
+          ...p,
+          password: p.password ? '****' : undefined,
+          customHeaders: p.customHeaders ? Object.fromEntries(Object.entries(p.customHeaders).map(([k]) => [k, '****'])) : undefined,
+        })),
+      } : undefined,
+      notifications: config.notifications ? {
+        ...config.notifications,
+        discordWebhook: config.notifications.discordWebhook ? '****' : undefined,
+        emailPassword: config.notifications.emailPassword ? '****' : undefined,
       } : undefined,
     };
     sendJson(res, 200, sanitized);
@@ -119,8 +144,11 @@ export const handleConfig = (res: any): void => {
  * @param options Server configuration options.
  */
 export const routeRequest = (req: any, res: any, options: ServerOptions): void => {
-  const url = req.url ?? '';
+  const fullUrl = req.url ?? '';
   const method = req.method ?? 'GET';
+
+  // Extract pathname without query parameters
+  const pathname = fullUrl.split('?')[0];
 
   const getHandlers: Record<string, (res: any) => void> = {
     '/health': handleHealth,
@@ -128,12 +156,12 @@ export const routeRequest = (req: any, res: any, options: ServerOptions): void =
     '/config': handleConfig,
   };
 
-  if (method === 'GET' && url in getHandlers) {
-    getHandlers[url](res);
+  if (method === 'GET' && pathname in getHandlers) {
+    getHandlers[pathname](res);
     return;
   }
 
-  if (method === 'POST' && url === '/analyze') {
+  if (method === 'POST' && pathname === '/analyze') {
     handleAnalyze(req, res, options);
     return;
   }


### PR DESCRIPTION
Fix sensitive data leak and DoS vulnerability in HTTP server

This commit addresses issue #251 with the following fixes in the HTTP server:
- Mask `discordWebhook`, `emailPassword`, and all `customHeaders` on AI providers in the `/config` endpoint to prevent leaking sensitive information.
- Introduce a 1MB payload size limit in `readBody` to prevent DoS via memory exhaustion. If the limit is exceeded, the request is paused and rejected with an error.
- Extract the pathname from `req.url` in `routeRequest` so query parameters are ignored for route dispatching.
- Add tests in `src/__tests__/server.test.ts` to verify these behaviors.

---
*PR created automatically by Jules for task [8837960669353095453](https://jules.google.com/task/8837960669353095453) started by @utkarsh232005*